### PR TITLE
feat: Instant Play - land on site and play vs bot immediately

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,29 +13,22 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 }
 
 function App() {
-  console.log('🚀 MakeFour App initialized - ready for development!')
-  console.log('Environment:', import.meta.env.MODE)
-  console.log('Timestamp:', new Date().toISOString())
-
   return (
     <ThemeProvider>
       <AuthProvider>
         <BrowserRouter>
           <Routes>
+            {/* Public routes */}
+            <Route path="/" element={<PlayPage />} />
+            <Route path="/play" element={<PlayPage />} />
             <Route path="/login" element={<LoginPage />} />
+
+            {/* Protected routes - require authentication */}
             <Route
               path="/dashboard"
               element={
                 <ProtectedRoute>
                   <DashboardPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
-              path="/play"
-              element={
-                <ProtectedRoute>
-                  <PlayPage />
                 </ProtectedRoute>
               }
             />
@@ -55,7 +48,6 @@ function App() {
                 </ProtectedRoute>
               }
             />
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -112,17 +112,6 @@ export default function GameBoard({
         </div>
       </div>
 
-      {/* Player color legend */}
-      <div className="flex gap-6 text-sm text-muted-foreground">
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded-full bg-red-500" />
-          <span>Player 1</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded-full bg-yellow-400" />
-          <span>Player 2</span>
-        </div>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Implements the core "instant play" experience where visitors land directly on the game and can start playing immediately against a bot opponent.

- **No login required** - anyone can play
- **Immediate start** - no mode selection, game is ready on page load
- **You vs Bot** - player is always red, bot is yellow
- **Smart UI** - shows turn status, disables board during bot's turn
- **Gentle auth prompt** - after game ends, guests see "Sign in to save games"

## Changes

- `src/App.tsx`: Make `/` and `/play` public routes
- `src/pages/PlayPage.tsx`: 
  - Add bot opponent logic using `suggestMove()` from AI coach
  - Add "You vs Bot" indicator
  - Handle player turn vs bot turn states
  - Conditional UI for authenticated vs guest users
- `src/components/GameBoard.tsx`: Remove generic "Player 1/2" legend

## Screenshots

The game now shows:
- "You (red) vs Bot (yellow)" indicator at top
- "Your turn" / "Bot is thinking..." / "You win!" status
- Login button for guests, Dashboard for authenticated users

## Test Plan

- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
- [ ] Manual test: Visit `/` as guest, play game against bot
- [ ] Manual test: Bot makes moves automatically after player
- [ ] Manual test: "Play Again" starts new game immediately
- [ ] Manual test: Logged-in user can save game

## Future Work (separate PRs)

- Improve AI (currently uses center-preference heuristic)
- Add human matchmaking (opportunistic, falls back to bot)
- Add difficulty selection

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)