### PR TITLE
feat: add AI opponent mode with selectable difficulty

### DIFF
--- a/functions/api/games/[id].ts
+++ b/functions/api/games/[id].ts
@@ -16,6 +16,9 @@ interface GameRow {
   outcome: string
   moves: string
   move_count: number
+  opponent_type: string
+  ai_difficulty: string | null
+  player_number: number
   created_at: number
 }
 
@@ -34,7 +37,7 @@ export async function onRequestGet(context: EventContext<Env, any, { id: string 
 
     // Fetch the game (only if it belongs to the user)
     const game = await DB.prepare(`
-      SELECT id, outcome, moves, move_count, created_at
+      SELECT id, outcome, moves, move_count, opponent_type, ai_difficulty, player_number, created_at
       FROM games
       WHERE id = ? AND user_id = ?
     `)
@@ -50,6 +53,9 @@ export async function onRequestGet(context: EventContext<Env, any, { id: string 
       outcome: game.outcome,
       moves: JSON.parse(game.moves),
       moveCount: game.move_count,
+      opponentType: game.opponent_type,
+      aiDifficulty: game.ai_difficulty,
+      playerNumber: game.player_number,
       createdAt: game.created_at,
     })
   } catch (error) {

--- a/schema.sql
+++ b/schema.sql
@@ -52,15 +52,24 @@ CREATE TABLE IF NOT EXISTS password_reset_tokens (
 CREATE TABLE IF NOT EXISTS games (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
-  -- Outcome from the perspective of player 1 (the user who started the game)
+  -- Outcome from the perspective of the user
   outcome TEXT NOT NULL,
   -- JSON array of column indices (0-6) representing each move
   moves TEXT NOT NULL,
   -- Total number of moves in the game
   move_count INTEGER NOT NULL,
+  -- Type of opponent: 'human' for hotseat, 'ai' for AI opponent
+  opponent_type TEXT NOT NULL DEFAULT 'ai',
+  -- AI difficulty level (null for human games)
+  ai_difficulty TEXT,
+  -- Which player the user played as (1 = red/first, 2 = yellow/second)
+  player_number INTEGER NOT NULL DEFAULT 1,
   created_at INTEGER NOT NULL,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  CHECK (outcome IN ('win', 'loss', 'draw'))
+  CHECK (outcome IN ('win', 'loss', 'draw')),
+  CHECK (opponent_type IN ('human', 'ai')),
+  CHECK (ai_difficulty IS NULL OR ai_difficulty IN ('beginner', 'intermediate', 'expert', 'perfect')),
+  CHECK (player_number IN (1, 2))
 );
 
 -- Indexes for users
@@ -79,3 +88,5 @@ CREATE INDEX IF NOT EXISTS idx_reset_tokens_user ON password_reset_tokens(user_i
 CREATE INDEX IF NOT EXISTS idx_games_user_id ON games(user_id);
 CREATE INDEX IF NOT EXISTS idx_games_created_at ON games(created_at);
 CREATE INDEX IF NOT EXISTS idx_games_outcome ON games(outcome);
+CREATE INDEX IF NOT EXISTS idx_games_opponent_type ON games(opponent_type);
+CREATE INDEX IF NOT EXISTS idx_games_ai_difficulty ON games(ai_difficulty);

--- a/src/pages/GamesPage.tsx
+++ b/src/pages/GamesPage.tsx
@@ -11,6 +11,9 @@ interface Game {
   outcome: 'win' | 'loss' | 'draw'
   moves: number[]
   moveCount: number
+  opponentType: 'human' | 'ai'
+  aiDifficulty: 'beginner' | 'intermediate' | 'expert' | 'perfect' | null
+  playerNumber: number
   createdAt: number
 }
 
@@ -96,6 +99,24 @@ export default function GamesPage() {
     }
   }
 
+  const getOpponentLabel = (game: Game) => {
+    if (game.opponentType === 'human') {
+      return 'Hotseat'
+    }
+    const difficultyLabels: Record<string, string> = {
+      beginner: 'Beginner',
+      intermediate: 'Intermediate',
+      expert: 'Expert',
+      perfect: 'Perfect',
+    }
+    return `vs AI (${difficultyLabels[game.aiDifficulty || 'intermediate']})`
+  }
+
+  const getPlayerColorLabel = (game: Game) => {
+    if (game.opponentType === 'human') return null
+    return game.playerNumber === 1 ? 'Red' : 'Yellow'
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       <header className="border-b bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
@@ -167,7 +188,13 @@ export default function GamesPage() {
                           </span>
                           <div>
                             <p className="text-sm font-medium">
+                              {getOpponentLabel(game)}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
                               {game.moveCount} moves
+                              {getPlayerColorLabel(game) && (
+                                <> · Played as {getPlayerColorLabel(game)}</>
+                              )}
                             </p>
                             <p className="text-xs text-muted-foreground">
                               {formatDate(game.createdAt)}

--- a/src/pages/PlayPage.tsx
+++ b/src/pages/PlayPage.tsx
@@ -10,9 +10,48 @@ import {
   createGameState,
   makeMove,
   type GameState,
+  type Player,
 } from '../game/makefour'
 import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi'
-import { suggestMove, analyzeThreats } from '../ai/coach'
+import { suggestMove, analyzeThreats, DIFFICULTY_LEVELS, type DifficultyLevel } from '../ai/coach'
+
+type GameMode = 'ai' | 'hotseat'
+type GamePhase = 'setup' | 'playing'
+
+interface GameSettings {
+  mode: GameMode
+  difficulty: DifficultyLevel
+  playerColor: Player // Which player the user plays as (1 = red/first, 2 = yellow/second)
+}
+
+const DEFAULT_SETTINGS: GameSettings = {
+  mode: 'ai',
+  difficulty: 'intermediate',
+  playerColor: 1,
+}
+
+// Load saved settings from localStorage
+function loadSettings(): GameSettings {
+  try {
+    const saved = localStorage.getItem('makefour-settings')
+    if (saved) {
+      const parsed = JSON.parse(saved)
+      return {
+        mode: parsed.mode || DEFAULT_SETTINGS.mode,
+        difficulty: parsed.difficulty || DEFAULT_SETTINGS.difficulty,
+        playerColor: parsed.playerColor || DEFAULT_SETTINGS.playerColor,
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return DEFAULT_SETTINGS
+}
+
+// Save settings to localStorage
+function saveSettings(settings: GameSettings) {
+  localStorage.setItem('makefour-settings', JSON.stringify(settings))
+}
 
 export default function PlayPage() {
   const { logout, user, isAuthenticated } = useAuth()
@@ -22,12 +61,13 @@ export default function PlayPage() {
   const [saveError, setSaveError] = useState<string | null>(null)
   const [gameSaved, setGameSaved] = useState(false)
   const [isBotThinking, setIsBotThinking] = useState(false)
+  const [gamePhase, setGamePhase] = useState<GamePhase>('setup')
+  const [settings, setSettings] = useState<GameSettings>(loadSettings)
   const [showAnalysis, setShowAnalysis] = useState(false)
 
-  // Player is always Player 1 (red), Bot is Player 2 (yellow)
-  const playerNumber = 1
-  const botNumber = 2
-  const isPlayerTurn = gameState.currentPlayer === playerNumber && gameState.winner === null
+  // Determine player numbers based on settings
+  const userPlayerNumber = settings.playerColor
+  const aiPlayerNumber: Player = settings.playerColor === 1 ? 2 : 1
   const isGameOver = gameState.winner !== null
 
   // Compute threats for highlighting (memoized for performance)
@@ -37,11 +77,11 @@ export default function PlayPage() {
     return analysis.threats
   }, [gameState.board, gameState.currentPlayer, showAnalysis, isGameOver])
 
-  // Bot makes a move when it's the bot's turn
+  // AI makes a move when it's the AI's turn in AI mode
   useEffect(() => {
-    if (gameState.currentPlayer !== botNumber || gameState.winner !== null) {
-      return
-    }
+    if (gamePhase !== 'playing') return
+    if (settings.mode !== 'ai') return
+    if (gameState.currentPlayer !== aiPlayerNumber || gameState.winner !== null) return
 
     setIsBotThinking(true)
 
@@ -49,11 +89,14 @@ export default function PlayPage() {
       // Small delay for UX - makes it feel like the bot is "thinking"
       await new Promise((resolve) => setTimeout(resolve, 500))
 
-      const botMove = await suggestMove({
-        board: gameState.board,
-        currentPlayer: gameState.currentPlayer,
-        moveHistory: gameState.moveHistory,
-      })
+      const botMove = await suggestMove(
+        {
+          board: gameState.board,
+          currentPlayer: gameState.currentPlayer,
+          moveHistory: gameState.moveHistory,
+        },
+        settings.difficulty
+      )
 
       const newState = makeMove(gameState, botMove)
       if (newState) {
@@ -63,21 +106,46 @@ export default function PlayPage() {
     }
 
     makeBotMove()
-  }, [gameState])
+  }, [gameState, gamePhase, settings.mode, settings.difficulty, aiPlayerNumber])
 
-  const handleColumnClick = useCallback((column: number) => {
-    // Only allow clicks on player's turn
-    if (!isPlayerTurn || isBotThinking) return
+  const handleColumnClick = useCallback(
+    (column: number) => {
+      if (gamePhase !== 'playing') return
+      if (gameState.winner !== null) return
 
-    const newState = makeMove(gameState, column)
-    if (newState) {
-      setGameState(newState)
-      setGameSaved(false)
-      setSaveError(null)
-    }
-  }, [gameState, isPlayerTurn, isBotThinking])
+      // In AI mode, only allow clicks on user's turn
+      if (settings.mode === 'ai' && (gameState.currentPlayer !== userPlayerNumber || isBotThinking)) {
+        return
+      }
+
+      const newState = makeMove(gameState, column)
+      if (newState) {
+        setGameState(newState)
+        setGameSaved(false)
+        setSaveError(null)
+      }
+    },
+    [gameState, gamePhase, settings.mode, userPlayerNumber, isBotThinking]
+  )
+
+  const handleStartGame = useCallback(() => {
+    saveSettings(settings)
+    setGameState(createGameState())
+    setGameSaved(false)
+    setSaveError(null)
+    setIsBotThinking(false)
+    setGamePhase('playing')
+  }, [settings])
 
   const handleNewGame = useCallback(() => {
+    setGamePhase('setup')
+    setGameState(createGameState())
+    setGameSaved(false)
+    setSaveError(null)
+    setIsBotThinking(false)
+  }, [])
+
+  const handlePlayAgain = useCallback(() => {
     setGameState(createGameState())
     setGameSaved(false)
     setSaveError(null)
@@ -91,11 +159,14 @@ export default function PlayPage() {
     setSaveError(null)
 
     try {
-      // Determine outcome from player's perspective (Player 1)
+      // Determine outcome from user's perspective
       let outcome: 'win' | 'loss' | 'draw'
       if (gameState.winner === 'draw') {
         outcome = 'draw'
-      } else if (gameState.winner === playerNumber) {
+      } else if (settings.mode === 'hotseat') {
+        // In hotseat mode, outcome is from perspective of player 1
+        outcome = gameState.winner === 1 ? 'win' : 'loss'
+      } else if (gameState.winner === userPlayerNumber) {
         outcome = 'win'
       } else {
         outcome = 'loss'
@@ -106,6 +177,9 @@ export default function PlayPage() {
         body: JSON.stringify({
           outcome,
           moves: gameState.moveHistory,
+          opponentType: settings.mode === 'ai' ? 'ai' : 'human',
+          aiDifficulty: settings.mode === 'ai' ? settings.difficulty : null,
+          playerNumber: settings.mode === 'ai' ? userPlayerNumber : 1,
         }),
       })
 
@@ -115,39 +189,281 @@ export default function PlayPage() {
     } finally {
       setIsSaving(false)
     }
-  }, [gameState, gameSaved, apiCall])
+  }, [gameState, gameSaved, apiCall, settings, userPlayerNumber])
 
   const getStatusMessage = (): string => {
     if (gameState.winner === 'draw') {
       return "It's a draw!"
     }
-    if (gameState.winner === playerNumber) {
+    if (settings.mode === 'hotseat') {
+      if (gameState.winner) {
+        return `Player ${gameState.winner} wins!`
+      }
+      return `Player ${gameState.currentPlayer}'s turn`
+    }
+    // AI mode
+    if (gameState.winner === userPlayerNumber) {
       return 'You win!'
     }
-    if (gameState.winner === botNumber) {
-      return 'Bot wins!'
+    if (gameState.winner === aiPlayerNumber) {
+      return 'AI wins!'
     }
     if (isBotThinking) {
-      return 'Bot is thinking...'
+      return 'AI is thinking...'
     }
     return 'Your turn'
   }
 
   const getStatusColor = (): string => {
-    if (gameState.winner === playerNumber) {
-      return 'text-green-600 dark:text-green-400'
-    }
-    if (gameState.winner === botNumber) {
-      return 'text-red-500'
-    }
     if (gameState.winner === 'draw') {
       return 'text-muted-foreground'
+    }
+    if (settings.mode === 'hotseat') {
+      if (gameState.winner) {
+        return gameState.winner === 1 ? 'text-red-500' : 'text-yellow-500'
+      }
+      return gameState.currentPlayer === 1 ? 'text-red-500' : 'text-yellow-500'
+    }
+    // AI mode
+    if (gameState.winner === userPlayerNumber) {
+      return 'text-green-600 dark:text-green-400'
+    }
+    if (gameState.winner === aiPlayerNumber) {
+      return 'text-red-500'
     }
     if (isBotThinking) {
       return 'text-yellow-500'
     }
-    return 'text-red-500' // Player's color
+    return userPlayerNumber === 1 ? 'text-red-500' : 'text-yellow-500'
   }
+
+  const renderSetupScreen = () => (
+    <Card>
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl">New Game</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Game Mode Selection */}
+        <div>
+          <label className="block text-sm font-medium mb-2">Game Mode</label>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              variant={settings.mode === 'ai' ? 'default' : 'outline'}
+              onClick={() => setSettings({ ...settings, mode: 'ai' })}
+              className="h-auto py-3"
+            >
+              <div className="text-center">
+                <div className="font-medium">vs AI</div>
+                <div className="text-xs opacity-80">Play against the computer</div>
+              </div>
+            </Button>
+            <Button
+              variant={settings.mode === 'hotseat' ? 'default' : 'outline'}
+              onClick={() => setSettings({ ...settings, mode: 'hotseat' })}
+              className="h-auto py-3"
+            >
+              <div className="text-center">
+                <div className="font-medium">Hotseat</div>
+                <div className="text-xs opacity-80">Two players, one device</div>
+              </div>
+            </Button>
+          </div>
+        </div>
+
+        {/* AI-specific settings */}
+        {settings.mode === 'ai' && (
+          <>
+            {/* Difficulty Selection */}
+            <div>
+              <label className="block text-sm font-medium mb-2">Difficulty</label>
+              <div className="grid grid-cols-2 gap-2">
+                {(Object.keys(DIFFICULTY_LEVELS) as DifficultyLevel[]).map((level) => (
+                  <Button
+                    key={level}
+                    variant={settings.difficulty === level ? 'default' : 'outline'}
+                    onClick={() => setSettings({ ...settings, difficulty: level })}
+                    className="h-auto py-2"
+                  >
+                    <div className="text-center">
+                      <div className="font-medium">{DIFFICULTY_LEVELS[level].name}</div>
+                      <div className="text-xs opacity-80">{DIFFICULTY_LEVELS[level].description}</div>
+                    </div>
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            {/* Player Color Selection */}
+            <div>
+              <label className="block text-sm font-medium mb-2">Play as</label>
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  variant={settings.playerColor === 1 ? 'default' : 'outline'}
+                  onClick={() => setSettings({ ...settings, playerColor: 1 })}
+                  className="h-auto py-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="w-4 h-4 rounded-full bg-red-500" />
+                    <div>
+                      <div className="font-medium">Red</div>
+                      <div className="text-xs opacity-80">Goes first</div>
+                    </div>
+                  </div>
+                </Button>
+                <Button
+                  variant={settings.playerColor === 2 ? 'default' : 'outline'}
+                  onClick={() => setSettings({ ...settings, playerColor: 2 })}
+                  className="h-auto py-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="w-4 h-4 rounded-full bg-yellow-400" />
+                    <div>
+                      <div className="font-medium">Yellow</div>
+                      <div className="text-xs opacity-80">Goes second</div>
+                    </div>
+                  </div>
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Start Button */}
+        <Button onClick={handleStartGame} size="lg" className="w-full">
+          Start Game
+        </Button>
+      </CardContent>
+    </Card>
+  )
+
+  const renderGameScreen = () => (
+    <Card>
+      <CardHeader className="text-center pb-2">
+        <div className="flex justify-center items-center gap-4 mb-2">
+          {settings.mode === 'ai' ? (
+            <>
+              <div className="flex items-center gap-2">
+                <div
+                  className={`w-4 h-4 rounded-full ${userPlayerNumber === 1 ? 'bg-red-500' : 'bg-yellow-400'}`}
+                />
+                <span className="text-sm font-medium">You</span>
+              </div>
+              <span className="text-muted-foreground">vs</span>
+              <div className="flex items-center gap-2">
+                <div
+                  className={`w-4 h-4 rounded-full ${aiPlayerNumber === 1 ? 'bg-red-500' : 'bg-yellow-400'}`}
+                />
+                <span className="text-sm font-medium">
+                  AI ({DIFFICULTY_LEVELS[settings.difficulty].name})
+                </span>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-full bg-red-500" />
+                <span className="text-sm font-medium">Player 1</span>
+              </div>
+              <span className="text-muted-foreground">vs</span>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-full bg-yellow-400" />
+                <span className="text-sm font-medium">Player 2</span>
+              </div>
+            </>
+          )}
+        </div>
+        <CardTitle className={`text-2xl ${getStatusColor()}`}>{getStatusMessage()}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-6">
+        <GameBoard
+          board={gameState.board}
+          currentPlayer={gameState.currentPlayer}
+          winner={gameState.winner}
+          onColumnClick={handleColumnClick}
+          disabled={
+            gameState.winner !== null ||
+            (settings.mode === 'ai' && (gameState.currentPlayer !== userPlayerNumber || isBotThinking))
+          }
+          threats={threats}
+          showThreats={showAnalysis}
+        />
+
+        {/* Analysis toggle and panel */}
+        <div className="w-full space-y-3">
+          <label className="flex items-center gap-2 cursor-pointer justify-center">
+            <input
+              type="checkbox"
+              checked={showAnalysis}
+              onChange={(e) => setShowAnalysis(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="text-sm text-muted-foreground">Show analysis</span>
+          </label>
+
+          {showAnalysis && (
+            <AnalysisPanel
+              board={gameState.board}
+              currentPlayer={gameState.currentPlayer}
+              isGameOver={isGameOver}
+            />
+          )}
+        </div>
+
+        <div className="flex flex-col gap-3 w-full">
+          {/* Game over actions */}
+          {gameState.winner !== null && (
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-2 justify-center">
+                <Button onClick={handlePlayAgain} size="lg">
+                  Play Again
+                </Button>
+                <Button onClick={handleNewGame} variant="outline" size="lg">
+                  Change Settings
+                </Button>
+              </div>
+              {isAuthenticated && !gameSaved && (
+                <div className="flex justify-center">
+                  <Button onClick={handleSaveGame} variant="outline" disabled={isSaving}>
+                    {isSaving ? 'Saving...' : 'Save Game'}
+                  </Button>
+                </div>
+              )}
+              {isAuthenticated && gameSaved && (
+                <p className="text-center text-sm text-green-600 dark:text-green-400">
+                  Game saved to history!
+                </p>
+              )}
+              {isAuthenticated && saveError && (
+                <p className="text-center text-sm text-red-600 dark:text-red-400">{saveError}</p>
+              )}
+              {!isAuthenticated && (
+                <p className="text-center text-sm text-muted-foreground">
+                  <Link to="/login" className="text-primary hover:underline">
+                    Sign in
+                  </Link>{' '}
+                  to save games and track your progress
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Mid-game actions */}
+          {gameState.winner === null && gameState.moveHistory.length > 0 && (
+            <div className="flex gap-2 justify-center">
+              <Button onClick={handleNewGame} variant="outline" size="sm">
+                New Game
+              </Button>
+            </div>
+          )}
+
+          {/* Move counter */}
+          <p className="text-center text-sm text-muted-foreground">
+            Moves: {gameState.moveHistory.length}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
@@ -157,9 +473,7 @@ export default function PlayPage() {
             <Link to="/" className="text-2xl font-bold hover:opacity-80">
               MakeFour
             </Link>
-            {user && (
-              <p className="text-xs text-muted-foreground">{user.email}</p>
-            )}
+            {user && <p className="text-xs text-muted-foreground">{user.email}</p>}
           </div>
           <div className="flex gap-2">
             {isAuthenticated ? (
@@ -190,111 +504,7 @@ export default function PlayPage() {
 
       <main className="container mx-auto px-4 py-8">
         <div className="max-w-lg mx-auto">
-          <Card>
-            <CardHeader className="text-center pb-2">
-              <div className="flex justify-center items-center gap-4 mb-2">
-                <div className="flex items-center gap-2">
-                  <div className="w-4 h-4 rounded-full bg-red-500" />
-                  <span className="text-sm font-medium">You</span>
-                </div>
-                <span className="text-muted-foreground">vs</span>
-                <div className="flex items-center gap-2">
-                  <div className="w-4 h-4 rounded-full bg-yellow-400" />
-                  <span className="text-sm font-medium">Bot</span>
-                </div>
-              </div>
-              <CardTitle className={`text-2xl ${getStatusColor()}`}>
-                {getStatusMessage()}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="flex flex-col items-center gap-6">
-              <GameBoard
-                board={gameState.board}
-                currentPlayer={gameState.currentPlayer}
-                winner={gameState.winner}
-                onColumnClick={handleColumnClick}
-                disabled={!isPlayerTurn || isBotThinking}
-                threats={threats}
-                showThreats={showAnalysis}
-              />
-
-              {/* Analysis toggle and panel */}
-              <div className="w-full space-y-3">
-                <label className="flex items-center gap-2 cursor-pointer justify-center">
-                  <input
-                    type="checkbox"
-                    checked={showAnalysis}
-                    onChange={(e) => setShowAnalysis(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <span className="text-sm text-muted-foreground">Show analysis</span>
-                </label>
-
-                {showAnalysis && (
-                  <AnalysisPanel
-                    board={gameState.board}
-                    currentPlayer={gameState.currentPlayer}
-                    isGameOver={isGameOver}
-                  />
-                )}
-              </div>
-
-              <div className="flex flex-col gap-3 w-full">
-                {/* Game over actions */}
-                {gameState.winner !== null && (
-                  <div className="flex flex-col gap-2">
-                    <div className="flex gap-2 justify-center">
-                      <Button onClick={handleNewGame} size="lg">
-                        Play Again
-                      </Button>
-                      {isAuthenticated && !gameSaved && (
-                        <Button
-                          onClick={handleSaveGame}
-                          variant="outline"
-                          size="lg"
-                          disabled={isSaving}
-                        >
-                          {isSaving ? 'Saving...' : 'Save Game'}
-                        </Button>
-                      )}
-                    </div>
-                    {isAuthenticated && gameSaved && (
-                      <p className="text-center text-sm text-green-600 dark:text-green-400">
-                        Game saved to history!
-                      </p>
-                    )}
-                    {isAuthenticated && saveError && (
-                      <p className="text-center text-sm text-red-600 dark:text-red-400">
-                        {saveError}
-                      </p>
-                    )}
-                    {!isAuthenticated && (
-                      <p className="text-center text-sm text-muted-foreground">
-                        <Link to="/login" className="text-primary hover:underline">
-                          Sign in
-                        </Link>
-                        {' '}to save games and track your progress
-                      </p>
-                    )}
-                  </div>
-                )}
-
-                {/* Mid-game actions */}
-                {gameState.winner === null && gameState.moveHistory.length > 0 && (
-                  <div className="flex gap-2 justify-center">
-                    <Button onClick={handleNewGame} variant="outline" size="sm">
-                      New Game
-                    </Button>
-                  </div>
-                )}
-
-                {/* Move counter */}
-                <p className="text-center text-sm text-muted-foreground">
-                  Moves: {gameState.moveHistory.length}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
+          {gamePhase === 'setup' ? renderSetupScreen() : renderGameScreen()}
         </div>
       </main>
     </div>

--- a/src/pages/ReplayPage.tsx
+++ b/src/pages/ReplayPage.tsx
@@ -21,6 +21,9 @@ interface GameData {
   outcome: 'win' | 'loss' | 'draw'
   moves: number[]
   moveCount: number
+  opponentType: 'human' | 'ai'
+  aiDifficulty: 'beginner' | 'intermediate' | 'expert' | 'perfect' | null
+  playerNumber: number
   createdAt: number
 }
 
@@ -165,6 +168,24 @@ export default function ReplayPage() {
     }
   }
 
+  const getOpponentLabel = (gameData: GameData) => {
+    if (gameData.opponentType === 'human') {
+      return 'Hotseat'
+    }
+    const difficultyLabels: Record<string, string> = {
+      beginner: 'Beginner',
+      intermediate: 'Intermediate',
+      expert: 'Expert',
+      perfect: 'Perfect',
+    }
+    return `vs AI (${difficultyLabels[gameData.aiDifficulty || 'intermediate']})`
+  }
+
+  const getPlayerColorLabel = (gameData: GameData) => {
+    if (gameData.opponentType === 'human') return null
+    return gameData.playerNumber === 1 ? 'Red' : 'Yellow'
+  }
+
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
@@ -223,6 +244,10 @@ export default function ReplayPage() {
             <CardHeader className="text-center">
               <CardTitle className="text-2xl">Game Replay</CardTitle>
               <p className="text-muted-foreground">{formatDate(game.createdAt)}</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                {getOpponentLabel(game)}
+                {getPlayerColorLabel(game) && <> · Played as {getPlayerColorLabel(game)}</>}
+              </p>
               <p className="text-lg font-semibold mt-2">{getOutcomeLabel(game.outcome)}</p>
             </CardHeader>
             <CardContent className="flex flex-col items-center gap-6">


### PR DESCRIPTION
## Summary

- Add game setup screen with mode selection (vs AI, Hotseat)
- Implement difficulty selection (Beginner, Intermediate, Expert, Perfect)
- Allow player to choose color (Red/Yellow) when playing against AI
- Remember last selected settings in localStorage
- Add opponent_type, ai_difficulty, player_number columns to games table
- Update API endpoints to handle new game metadata
- Display AI difficulty and player color in game history
- Show opponent info in replay page

## Test plan

- [ ] Verify game mode selection works (vs AI and Hotseat modes)
- [ ] Test all difficulty levels (Beginner, Intermediate, Expert, Perfect)
- [ ] Verify player color selection allows playing as Red or Yellow
- [ ] Confirm settings are remembered between sessions
- [ ] Test game saving with new metadata fields
- [ ] Check game history displays opponent type and difficulty
- [ ] Verify replay page shows AI metadata correctly
- [ ] Run `pnpm run build` to ensure no TypeScript errors
- [ ] Run `pnpm run test` to ensure all tests pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)