### PR TITLE
feat: implement online matchmaking for real-time multiplayer

### DIFF
--- a/functions/api/match/[id].ts
+++ b/functions/api/match/[id].ts
@@ -1,0 +1,388 @@
+/**
+ * Match API endpoint for active online games
+ *
+ * GET /api/match/:id - Get game state (poll for updates)
+ * POST /api/match/:id - Submit a move
+ */
+
+import { validateSession, errorResponse, jsonResponse } from '../../lib/auth'
+import { replayMoves, makeMove, isValidMove, createGameState } from '../../lib/game'
+import { calculateNewRating, GameOutcome } from '../../lib/elo'
+import { z } from 'zod'
+
+interface Env {
+  DB: D1Database
+}
+
+interface ActiveGameRow {
+  id: string
+  player1_id: string
+  player2_id: string
+  moves: string
+  current_turn: number
+  status: string
+  mode: string
+  winner: string | null
+  player1_rating: number
+  player2_rating: number
+  last_move_at: number
+  created_at: number
+  updated_at: number
+}
+
+interface UserRow {
+  id: string
+  rating: number
+  games_played: number
+}
+
+const moveSchema = z.object({
+  column: z.number().int().min(0).max(6),
+})
+
+/**
+ * GET /api/match/:id - Get current game state
+ */
+export async function onRequestGet(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+  const gameId = context.params.id as string
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Get the game
+    const game = await DB.prepare(`
+      SELECT id, player1_id, player2_id, moves, current_turn, status, mode,
+             winner, player1_rating, player2_rating, last_move_at, created_at, updated_at
+      FROM active_games
+      WHERE id = ?
+    `)
+      .bind(gameId)
+      .first<ActiveGameRow>()
+
+    if (!game) {
+      return errorResponse('Game not found', 404)
+    }
+
+    // Verify user is a participant
+    if (game.player1_id !== session.userId && game.player2_id !== session.userId) {
+      return errorResponse('You are not a participant in this game', 403)
+    }
+
+    const playerNumber = game.player1_id === session.userId ? 1 : 2
+    const moves = JSON.parse(game.moves) as number[]
+
+    // Reconstruct board state from moves
+    const gameState = moves.length > 0 ? replayMoves(moves) : createGameState()
+
+    return jsonResponse({
+      id: game.id,
+      playerNumber,
+      currentTurn: game.current_turn,
+      moves,
+      board: gameState?.board ?? null,
+      status: game.status,
+      winner: game.winner,
+      mode: game.mode,
+      opponentRating: playerNumber === 1 ? game.player2_rating : game.player1_rating,
+      lastMoveAt: game.last_move_at,
+      createdAt: game.created_at,
+      isYourTurn: game.status === 'active' && game.current_turn === playerNumber,
+    })
+  } catch (error) {
+    console.error('GET /api/match/:id error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+/**
+ * POST /api/match/:id - Submit a move
+ */
+export async function onRequestPost(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+  const gameId = context.params.id as string
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Parse request body
+    const body = await context.request.json()
+    const parseResult = moveSchema.safeParse(body)
+
+    if (!parseResult.success) {
+      return errorResponse(parseResult.error.errors[0].message, 400)
+    }
+
+    const { column } = parseResult.data
+
+    // Get the game
+    const game = await DB.prepare(`
+      SELECT id, player1_id, player2_id, moves, current_turn, status, mode,
+             winner, player1_rating, player2_rating, last_move_at, created_at, updated_at
+      FROM active_games
+      WHERE id = ?
+    `)
+      .bind(gameId)
+      .first<ActiveGameRow>()
+
+    if (!game) {
+      return errorResponse('Game not found', 404)
+    }
+
+    // Verify user is a participant
+    if (game.player1_id !== session.userId && game.player2_id !== session.userId) {
+      return errorResponse('You are not a participant in this game', 403)
+    }
+
+    // Check game is active
+    if (game.status !== 'active') {
+      return errorResponse('Game is not active', 400)
+    }
+
+    const playerNumber = game.player1_id === session.userId ? 1 : 2
+
+    // Check it's their turn
+    if (game.current_turn !== playerNumber) {
+      return errorResponse('Not your turn', 400)
+    }
+
+    // Validate and apply the move
+    const moves = JSON.parse(game.moves) as number[]
+    const currentState = moves.length > 0 ? replayMoves(moves) : createGameState()
+
+    if (!currentState) {
+      return errorResponse('Invalid game state', 500)
+    }
+
+    if (!isValidMove(currentState.board, column)) {
+      return errorResponse('Invalid move: column is full or out of bounds', 400)
+    }
+
+    const newState = makeMove(currentState, column)
+    if (!newState) {
+      return errorResponse('Invalid move', 400)
+    }
+
+    const now = Date.now()
+    const newMoves = [...moves, column]
+    const nextTurn = playerNumber === 1 ? 2 : 1
+
+    // Check for game end
+    let newStatus = 'active'
+    let winner: string | null = null
+
+    if (newState.winner !== null) {
+      newStatus = 'completed'
+      winner = newState.winner === 'draw' ? 'draw' : String(newState.winner)
+    }
+
+    // Update the game
+    await DB.prepare(`
+      UPDATE active_games
+      SET moves = ?, current_turn = ?, status = ?, winner = ?,
+          last_move_at = ?, updated_at = ?
+      WHERE id = ?
+    `).bind(
+      JSON.stringify(newMoves),
+      nextTurn,
+      newStatus,
+      winner,
+      now,
+      now,
+      gameId
+    ).run()
+
+    // If game is completed, update ELO ratings
+    if (newStatus === 'completed' && game.mode === 'ranked') {
+      await updateRatings(DB, game, winner, newMoves, now)
+    }
+
+    return jsonResponse({
+      success: true,
+      moves: newMoves,
+      board: newState.board,
+      currentTurn: nextTurn,
+      status: newStatus,
+      winner,
+      isYourTurn: newStatus === 'active' && nextTurn === playerNumber,
+    })
+  } catch (error) {
+    console.error('POST /api/match/:id error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+/**
+ * Update ELO ratings after game completion
+ */
+async function updateRatings(
+  DB: D1Database,
+  game: ActiveGameRow,
+  winner: string | null,
+  moves: number[],
+  now: number
+) {
+  // Get both players' current stats
+  const [player1, player2] = await Promise.all([
+    DB.prepare('SELECT id, rating, games_played FROM users WHERE id = ?')
+      .bind(game.player1_id)
+      .first<UserRow>(),
+    DB.prepare('SELECT id, rating, games_played FROM users WHERE id = ?')
+      .bind(game.player2_id)
+      .first<UserRow>(),
+  ])
+
+  if (!player1 || !player2) {
+    console.error('Could not find players for rating update')
+    return
+  }
+
+  // Determine outcomes
+  let player1Outcome: GameOutcome
+  let player2Outcome: GameOutcome
+
+  if (winner === 'draw') {
+    player1Outcome = 'draw'
+    player2Outcome = 'draw'
+  } else if (winner === '1') {
+    player1Outcome = 'win'
+    player2Outcome = 'loss'
+  } else {
+    player1Outcome = 'loss'
+    player2Outcome = 'win'
+  }
+
+  // Calculate new ratings
+  const player1Result = calculateNewRating(
+    game.player1_rating,
+    game.player2_rating,
+    player1Outcome,
+    player1.games_played
+  )
+  const player2Result = calculateNewRating(
+    game.player2_rating,
+    game.player1_rating,
+    player2Outcome,
+    player2.games_played
+  )
+
+  // Generate IDs for records
+  const game1Id = crypto.randomUUID()
+  const game2Id = crypto.randomUUID()
+  const ratingHistory1Id = crypto.randomUUID()
+  const ratingHistory2Id = crypto.randomUUID()
+
+  // Update stats for both players
+  await DB.batch([
+    // Player 1 game record
+    DB.prepare(`
+      INSERT INTO games (id, user_id, outcome, moves, move_count, rating_change, opponent_type, player_number, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, 'human', 1, ?)
+    `).bind(
+      game1Id,
+      game.player1_id,
+      player1Outcome,
+      JSON.stringify(moves),
+      moves.length,
+      player1Result.ratingChange,
+      now
+    ),
+
+    // Player 2 game record
+    DB.prepare(`
+      INSERT INTO games (id, user_id, outcome, moves, move_count, rating_change, opponent_type, player_number, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, 'human', 2, ?)
+    `).bind(
+      game2Id,
+      game.player2_id,
+      player2Outcome,
+      JSON.stringify(moves),
+      moves.length,
+      player2Result.ratingChange,
+      now
+    ),
+
+    // Update player 1 stats
+    DB.prepare(`
+      UPDATE users SET
+        rating = ?,
+        games_played = games_played + 1,
+        wins = wins + ?,
+        losses = losses + ?,
+        draws = draws + ?,
+        updated_at = ?
+      WHERE id = ?
+    `).bind(
+      player1Result.newRating,
+      player1Outcome === 'win' ? 1 : 0,
+      player1Outcome === 'loss' ? 1 : 0,
+      player1Outcome === 'draw' ? 1 : 0,
+      now,
+      game.player1_id
+    ),
+
+    // Update player 2 stats
+    DB.prepare(`
+      UPDATE users SET
+        rating = ?,
+        games_played = games_played + 1,
+        wins = wins + ?,
+        losses = losses + ?,
+        draws = draws + ?,
+        updated_at = ?
+      WHERE id = ?
+    `).bind(
+      player2Result.newRating,
+      player2Outcome === 'win' ? 1 : 0,
+      player2Outcome === 'loss' ? 1 : 0,
+      player2Outcome === 'draw' ? 1 : 0,
+      now,
+      game.player2_id
+    ),
+
+    // Rating history for player 1
+    DB.prepare(`
+      INSERT INTO rating_history (id, user_id, game_id, rating_before, rating_after, rating_change, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      ratingHistory1Id,
+      game.player1_id,
+      game1Id,
+      game.player1_rating,
+      player1Result.newRating,
+      player1Result.ratingChange,
+      now
+    ),
+
+    // Rating history for player 2
+    DB.prepare(`
+      INSERT INTO rating_history (id, user_id, game_id, rating_before, rating_after, rating_change, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      ratingHistory2Id,
+      game.player2_id,
+      game2Id,
+      game.player2_rating,
+      player2Result.newRating,
+      player2Result.ratingChange,
+      now
+    ),
+  ])
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  })
+}

--- a/functions/api/match/[id]/resign.ts
+++ b/functions/api/match/[id]/resign.ts
@@ -1,0 +1,239 @@
+/**
+ * POST /api/match/:id/resign - Resign from an active game
+ */
+
+import { validateSession, errorResponse, jsonResponse } from '../../../lib/auth'
+import { calculateNewRating, GameOutcome } from '../../../lib/elo'
+
+interface Env {
+  DB: D1Database
+}
+
+interface ActiveGameRow {
+  id: string
+  player1_id: string
+  player2_id: string
+  moves: string
+  current_turn: number
+  status: string
+  mode: string
+  winner: string | null
+  player1_rating: number
+  player2_rating: number
+}
+
+interface UserRow {
+  id: string
+  rating: number
+  games_played: number
+}
+
+export async function onRequestPost(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+  const gameId = context.params.id as string
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Get the game
+    const game = await DB.prepare(`
+      SELECT id, player1_id, player2_id, moves, current_turn, status, mode,
+             winner, player1_rating, player2_rating
+      FROM active_games
+      WHERE id = ?
+    `)
+      .bind(gameId)
+      .first<ActiveGameRow>()
+
+    if (!game) {
+      return errorResponse('Game not found', 404)
+    }
+
+    // Verify user is a participant
+    if (game.player1_id !== session.userId && game.player2_id !== session.userId) {
+      return errorResponse('You are not a participant in this game', 403)
+    }
+
+    // Check game is active
+    if (game.status !== 'active') {
+      return errorResponse('Game is not active', 400)
+    }
+
+    const playerNumber = game.player1_id === session.userId ? 1 : 2
+    const winner = playerNumber === 1 ? '2' : '1' // Opponent wins
+    const now = Date.now()
+
+    // Update the game
+    await DB.prepare(`
+      UPDATE active_games
+      SET status = 'completed', winner = ?, updated_at = ?
+      WHERE id = ?
+    `).bind(winner, now, gameId).run()
+
+    // Update ELO ratings for ranked games
+    if (game.mode === 'ranked') {
+      await updateRatingsOnResign(DB, game, playerNumber, now)
+    }
+
+    return jsonResponse({
+      success: true,
+      status: 'completed',
+      winner,
+      resigned: true,
+    })
+  } catch (error) {
+    console.error('POST /api/match/:id/resign error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+async function updateRatingsOnResign(
+  DB: D1Database,
+  game: ActiveGameRow,
+  resigningPlayer: number,
+  now: number
+) {
+  const moves = JSON.parse(game.moves) as number[]
+
+  // Get both players' current stats
+  const [player1, player2] = await Promise.all([
+    DB.prepare('SELECT id, rating, games_played FROM users WHERE id = ?')
+      .bind(game.player1_id)
+      .first<UserRow>(),
+    DB.prepare('SELECT id, rating, games_played FROM users WHERE id = ?')
+      .bind(game.player2_id)
+      .first<UserRow>(),
+  ])
+
+  if (!player1 || !player2) {
+    console.error('Could not find players for rating update')
+    return
+  }
+
+  // Resigning player loses
+  const player1Outcome: GameOutcome = resigningPlayer === 1 ? 'loss' : 'win'
+  const player2Outcome: GameOutcome = resigningPlayer === 2 ? 'loss' : 'win'
+
+  const player1Result = calculateNewRating(
+    game.player1_rating,
+    game.player2_rating,
+    player1Outcome,
+    player1.games_played
+  )
+  const player2Result = calculateNewRating(
+    game.player2_rating,
+    game.player1_rating,
+    player2Outcome,
+    player2.games_played
+  )
+
+  const game1Id = crypto.randomUUID()
+  const game2Id = crypto.randomUUID()
+  const ratingHistory1Id = crypto.randomUUID()
+  const ratingHistory2Id = crypto.randomUUID()
+
+  await DB.batch([
+    // Player 1 game record
+    DB.prepare(`
+      INSERT INTO games (id, user_id, outcome, moves, move_count, rating_change, opponent_type, player_number, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, 'human', 1, ?)
+    `).bind(
+      game1Id,
+      game.player1_id,
+      player1Outcome,
+      JSON.stringify(moves),
+      moves.length,
+      player1Result.ratingChange,
+      now
+    ),
+
+    // Player 2 game record
+    DB.prepare(`
+      INSERT INTO games (id, user_id, outcome, moves, move_count, rating_change, opponent_type, player_number, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, 'human', 2, ?)
+    `).bind(
+      game2Id,
+      game.player2_id,
+      player2Outcome,
+      JSON.stringify(moves),
+      moves.length,
+      player2Result.ratingChange,
+      now
+    ),
+
+    // Update player 1 stats
+    DB.prepare(`
+      UPDATE users SET
+        rating = ?,
+        games_played = games_played + 1,
+        wins = wins + ?,
+        losses = losses + ?,
+        updated_at = ?
+      WHERE id = ?
+    `).bind(
+      player1Result.newRating,
+      player1Outcome === 'win' ? 1 : 0,
+      player1Outcome === 'loss' ? 1 : 0,
+      now,
+      game.player1_id
+    ),
+
+    // Update player 2 stats
+    DB.prepare(`
+      UPDATE users SET
+        rating = ?,
+        games_played = games_played + 1,
+        wins = wins + ?,
+        losses = losses + ?,
+        updated_at = ?
+      WHERE id = ?
+    `).bind(
+      player2Result.newRating,
+      player2Outcome === 'win' ? 1 : 0,
+      player2Outcome === 'loss' ? 1 : 0,
+      now,
+      game.player2_id
+    ),
+
+    // Rating history
+    DB.prepare(`
+      INSERT INTO rating_history (id, user_id, game_id, rating_before, rating_after, rating_change, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      ratingHistory1Id,
+      game.player1_id,
+      game1Id,
+      game.player1_rating,
+      player1Result.newRating,
+      player1Result.ratingChange,
+      now
+    ),
+
+    DB.prepare(`
+      INSERT INTO rating_history (id, user_id, game_id, rating_before, rating_after, rating_change, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      ratingHistory2Id,
+      game.player2_id,
+      game2Id,
+      game.player2_rating,
+      player2Result.newRating,
+      player2Result.ratingChange,
+      now
+    ),
+  ])
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  })
+}

--- a/functions/api/matchmaking/join.ts
+++ b/functions/api/matchmaking/join.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /api/matchmaking/join - Join the matchmaking queue
+ */
+
+import { validateSession, errorResponse, jsonResponse } from '../../lib/auth'
+import { z } from 'zod'
+
+interface Env {
+  DB: D1Database
+}
+
+const joinQueueSchema = z.object({
+  mode: z.enum(['ranked', 'casual']).default('ranked'),
+})
+
+interface UserRow {
+  id: string
+  rating: number
+}
+
+interface QueueEntry {
+  id: string
+  user_id: string
+  rating: number
+  mode: string
+  joined_at: number
+}
+
+interface ActiveGameRow {
+  id: string
+}
+
+export async function onRequestPost(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Parse request body
+    const body = await context.request.json().catch(() => ({}))
+    const parseResult = joinQueueSchema.safeParse(body)
+
+    if (!parseResult.success) {
+      return errorResponse(parseResult.error.errors[0].message, 400)
+    }
+
+    const { mode } = parseResult.data
+
+    // Check if user is already in an active game
+    const activeGame = await DB.prepare(`
+      SELECT id FROM active_games
+      WHERE (player1_id = ? OR player2_id = ?)
+      AND status = 'active'
+    `)
+      .bind(session.userId, session.userId)
+      .first<ActiveGameRow>()
+
+    if (activeGame) {
+      return errorResponse('You are already in an active game', 409)
+    }
+
+    // Check if user is already in queue
+    const existingEntry = await DB.prepare(`
+      SELECT id FROM matchmaking_queue WHERE user_id = ?
+    `)
+      .bind(session.userId)
+      .first<QueueEntry>()
+
+    if (existingEntry) {
+      return errorResponse('Already in matchmaking queue', 409)
+    }
+
+    // Get user's current rating
+    const user = await DB.prepare(`
+      SELECT id, rating FROM users WHERE id = ?
+    `)
+      .bind(session.userId)
+      .first<UserRow>()
+
+    if (!user) {
+      return errorResponse('User not found', 404)
+    }
+
+    // Add to queue
+    const queueId = crypto.randomUUID()
+    const now = Date.now()
+
+    await DB.prepare(`
+      INSERT INTO matchmaking_queue (id, user_id, rating, mode, initial_tolerance, joined_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).bind(queueId, session.userId, user.rating, mode, 100, now).run()
+
+    return jsonResponse({
+      status: 'queued',
+      queueId,
+      mode,
+      rating: user.rating,
+      joinedAt: now,
+    })
+  } catch (error) {
+    console.error('POST /api/matchmaking/join error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  })
+}

--- a/functions/api/matchmaking/leave.ts
+++ b/functions/api/matchmaking/leave.ts
@@ -1,0 +1,48 @@
+/**
+ * POST /api/matchmaking/leave - Leave the matchmaking queue
+ */
+
+import { validateSession, errorResponse, jsonResponse } from '../../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+export async function onRequestPost(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Remove user from queue
+    const result = await DB.prepare(`
+      DELETE FROM matchmaking_queue WHERE user_id = ?
+    `).bind(session.userId).run()
+
+    if (result.meta.changes === 0) {
+      return errorResponse('Not in matchmaking queue', 404)
+    }
+
+    return jsonResponse({
+      status: 'left',
+      message: 'Successfully left the matchmaking queue',
+    })
+  } catch (error) {
+    console.error('POST /api/matchmaking/leave error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  })
+}

--- a/functions/api/matchmaking/status.ts
+++ b/functions/api/matchmaking/status.ts
@@ -1,0 +1,229 @@
+/**
+ * GET /api/matchmaking/status - Check matchmaking status and try to find a match
+ *
+ * This endpoint is polled by the client to:
+ * 1. Check if still in queue
+ * 2. Attempt to find a suitable opponent
+ * 3. Create a game if match is found
+ */
+
+import { validateSession, errorResponse, jsonResponse } from '../../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+interface QueueEntry {
+  id: string
+  user_id: string
+  rating: number
+  mode: string
+  initial_tolerance: number
+  joined_at: number
+}
+
+interface UserRow {
+  id: string
+  email: string
+  rating: number
+}
+
+interface ActiveGameRow {
+  id: string
+  player1_id: string
+  player2_id: string
+  status: string
+}
+
+// Tolerance expands by 50 rating points every 10 seconds
+const TOLERANCE_EXPANSION_RATE = 50
+const TOLERANCE_EXPANSION_INTERVAL = 10000 // 10 seconds
+const MAX_TOLERANCE = 500
+
+export async function onRequestGet(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // First check if user is already in an active game
+    const activeGame = await DB.prepare(`
+      SELECT id, player1_id, player2_id, status
+      FROM active_games
+      WHERE (player1_id = ? OR player2_id = ?)
+      AND status = 'active'
+    `)
+      .bind(session.userId, session.userId)
+      .first<ActiveGameRow>()
+
+    if (activeGame) {
+      // User already has an active game - return it
+      return jsonResponse({
+        status: 'matched',
+        gameId: activeGame.id,
+        playerNumber: activeGame.player1_id === session.userId ? 1 : 2,
+      })
+    }
+
+    // Check if user is in queue
+    const queueEntry = await DB.prepare(`
+      SELECT id, user_id, rating, mode, initial_tolerance, joined_at
+      FROM matchmaking_queue
+      WHERE user_id = ?
+    `)
+      .bind(session.userId)
+      .first<QueueEntry>()
+
+    if (!queueEntry) {
+      return jsonResponse({
+        status: 'not_queued',
+      })
+    }
+
+    const now = Date.now()
+    const waitTime = now - queueEntry.joined_at
+
+    // Calculate current tolerance based on wait time
+    const toleranceExpansions = Math.floor(waitTime / TOLERANCE_EXPANSION_INTERVAL)
+    const currentTolerance = Math.min(
+      queueEntry.initial_tolerance + toleranceExpansions * TOLERANCE_EXPANSION_RATE,
+      MAX_TOLERANCE
+    )
+
+    // Try to find a match
+    // Look for other players in the same mode within rating tolerance
+    // Exclude self, order by closest rating then longest wait
+    const potentialMatches = await DB.prepare(`
+      SELECT id, user_id, rating, mode, initial_tolerance, joined_at
+      FROM matchmaking_queue
+      WHERE user_id != ?
+      AND mode = ?
+      AND ABS(rating - ?) <= ?
+      ORDER BY ABS(rating - ?) ASC, joined_at ASC
+      LIMIT 10
+    `)
+      .bind(
+        session.userId,
+        queueEntry.mode,
+        queueEntry.rating,
+        currentTolerance,
+        queueEntry.rating
+      )
+      .all<QueueEntry>()
+
+    // Find first match where both players are within each other's tolerance
+    let matchedOpponent: QueueEntry | null = null
+
+    for (const opponent of potentialMatches.results) {
+      const opponentWaitTime = now - opponent.joined_at
+      const opponentExpansions = Math.floor(opponentWaitTime / TOLERANCE_EXPANSION_INTERVAL)
+      const opponentTolerance = Math.min(
+        opponent.initial_tolerance + opponentExpansions * TOLERANCE_EXPANSION_RATE,
+        MAX_TOLERANCE
+      )
+
+      // Check if we're within each other's tolerance
+      const ratingDiff = Math.abs(queueEntry.rating - opponent.rating)
+      if (ratingDiff <= currentTolerance && ratingDiff <= opponentTolerance) {
+        matchedOpponent = opponent
+        break
+      }
+    }
+
+    if (!matchedOpponent) {
+      // No match found yet
+      return jsonResponse({
+        status: 'queued',
+        waitTime,
+        currentTolerance,
+        mode: queueEntry.mode,
+        rating: queueEntry.rating,
+      })
+    }
+
+    // Match found! Create the game
+    const gameId = crypto.randomUUID()
+
+    // Randomly assign player 1 and player 2
+    const player1IsUser = Math.random() < 0.5
+    const player1Id = player1IsUser ? session.userId : matchedOpponent.user_id
+    const player2Id = player1IsUser ? matchedOpponent.user_id : session.userId
+    const player1Rating = player1IsUser ? queueEntry.rating : matchedOpponent.rating
+    const player2Rating = player1IsUser ? matchedOpponent.rating : queueEntry.rating
+
+    // Get opponent info for response
+    const opponent = await DB.prepare(`
+      SELECT id, email, rating FROM users WHERE id = ?
+    `)
+      .bind(matchedOpponent.user_id)
+      .first<UserRow>()
+
+    try {
+      // Use a batch to atomically create game and remove both from queue
+      await DB.batch([
+        // Create the active game
+        DB.prepare(`
+          INSERT INTO active_games (
+            id, player1_id, player2_id, moves, current_turn, status, mode,
+            player1_rating, player2_rating, last_move_at, created_at, updated_at
+          )
+          VALUES (?, ?, ?, '[]', 1, 'active', ?, ?, ?, ?, ?, ?)
+        `).bind(
+          gameId,
+          player1Id,
+          player2Id,
+          queueEntry.mode,
+          player1Rating,
+          player2Rating,
+          now,
+          now,
+          now
+        ),
+
+        // Remove both players from queue
+        DB.prepare(`DELETE FROM matchmaking_queue WHERE user_id = ?`).bind(session.userId),
+        DB.prepare(`DELETE FROM matchmaking_queue WHERE user_id = ?`).bind(matchedOpponent.user_id),
+      ])
+
+      return jsonResponse({
+        status: 'matched',
+        gameId,
+        playerNumber: player1Id === session.userId ? 1 : 2,
+        opponent: opponent
+          ? {
+              rating: opponent.rating,
+            }
+          : null,
+        mode: queueEntry.mode,
+      })
+    } catch (dbError) {
+      // If batch fails (e.g., race condition where opponent was already matched),
+      // just return queued status - client will retry
+      console.error('Match creation failed:', dbError)
+      return jsonResponse({
+        status: 'queued',
+        waitTime,
+        currentTolerance,
+        mode: queueEntry.mode,
+        rating: queueEntry.rating,
+      })
+    }
+  } catch (error) {
+    console.error('GET /api/matchmaking/status error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  })
+}

--- a/functions/lib/game.ts
+++ b/functions/lib/game.ts
@@ -1,0 +1,191 @@
+/**
+ * Server-side game logic for MakeFour
+ * This is a minimal subset of the client-side game engine for move validation.
+ */
+
+export const ROWS = 6
+export const COLUMNS = 7
+export const WIN_LENGTH = 4
+
+export type Player = 1 | 2
+export type Cell = Player | null
+export type Board = Cell[][]
+export type GameResult = Player | 'draw' | null
+
+export interface GameState {
+  board: Board
+  currentPlayer: Player
+  winner: GameResult
+  moveHistory: number[]
+}
+
+/**
+ * Creates an empty game board.
+ */
+export function createEmptyBoard(): Board {
+  return Array.from({ length: ROWS }, () => Array(COLUMNS).fill(null))
+}
+
+/**
+ * Creates a new game state with an empty board.
+ */
+export function createGameState(): GameState {
+  return {
+    board: createEmptyBoard(),
+    currentPlayer: 1,
+    winner: null,
+    moveHistory: [],
+  }
+}
+
+/**
+ * Deep clones a board.
+ */
+export function cloneBoard(board: Board): Board {
+  return board.map((row) => [...row])
+}
+
+/**
+ * Gets the row where a piece would land in the given column.
+ * Returns -1 if the column is full.
+ */
+export function getAvailableRow(board: Board, column: number): number {
+  if (column < 0 || column >= COLUMNS) {
+    return -1
+  }
+  for (let row = ROWS - 1; row >= 0; row--) {
+    if (board[row][column] === null) {
+      return row
+    }
+  }
+  return -1
+}
+
+/**
+ * Checks if a move is valid.
+ */
+export function isValidMove(board: Board, column: number): boolean {
+  return getAvailableRow(board, column) !== -1
+}
+
+/**
+ * Checks if the board is completely full.
+ */
+export function isBoardFull(board: Board): boolean {
+  for (let col = 0; col < COLUMNS; col++) {
+    if (board[0][col] === null) return false
+  }
+  return true
+}
+
+/**
+ * Applies a move to the board, returning a new board state.
+ */
+export function applyMove(
+  board: Board,
+  column: number,
+  player: Player
+): { success: boolean; board: Board | null; row: number } {
+  const row = getAvailableRow(board, column)
+  if (row === -1) {
+    return { success: false, board: null, row: -1 }
+  }
+  const newBoard = cloneBoard(board)
+  newBoard[row][column] = player
+  return { success: true, board: newBoard, row }
+}
+
+/**
+ * Helper: Checks if WIN_LENGTH consecutive cells match the given player.
+ */
+function checkLine(
+  board: Board,
+  startRow: number,
+  startCol: number,
+  deltaRow: number,
+  deltaCol: number,
+  player: Player
+): boolean {
+  for (let i = 0; i < WIN_LENGTH; i++) {
+    const row = startRow + i * deltaRow
+    const col = startCol + i * deltaCol
+    if (board[row][col] !== player) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Checks for a winner on the board.
+ */
+export function checkWinner(board: Board): GameResult {
+  for (let row = 0; row < ROWS; row++) {
+    for (let col = 0; col < COLUMNS; col++) {
+      const cell = board[row][col]
+      if (cell === null) continue
+
+      // Horizontal
+      if (col + WIN_LENGTH - 1 < COLUMNS && checkLine(board, row, col, 0, 1, cell)) {
+        return cell
+      }
+      // Vertical
+      if (row + WIN_LENGTH - 1 < ROWS && checkLine(board, row, col, 1, 0, cell)) {
+        return cell
+      }
+      // Diagonal down-right
+      if (row + WIN_LENGTH - 1 < ROWS && col + WIN_LENGTH - 1 < COLUMNS && checkLine(board, row, col, 1, 1, cell)) {
+        return cell
+      }
+      // Diagonal down-left
+      if (row + WIN_LENGTH - 1 < ROWS && col - WIN_LENGTH + 1 >= 0 && checkLine(board, row, col, 1, -1, cell)) {
+        return cell
+      }
+    }
+  }
+
+  if (isBoardFull(board)) {
+    return 'draw'
+  }
+
+  return null
+}
+
+/**
+ * Makes a move and returns the updated game state.
+ */
+export function makeMove(state: GameState, column: number): GameState | null {
+  if (state.winner !== null) {
+    return null
+  }
+
+  const result = applyMove(state.board, column, state.currentPlayer)
+  if (!result.success || result.board === null) {
+    return null
+  }
+
+  const winner = checkWinner(result.board)
+  const nextPlayer: Player = state.currentPlayer === 1 ? 2 : 1
+
+  return {
+    board: result.board,
+    currentPlayer: winner === null ? nextPlayer : state.currentPlayer,
+    winner,
+    moveHistory: [...state.moveHistory, column],
+  }
+}
+
+/**
+ * Replays a game from a list of moves.
+ */
+export function replayMoves(moves: number[]): GameState | null {
+  let state = createGameState()
+  for (const column of moves) {
+    const newState = makeMove(state, column)
+    if (newState === null) {
+      return null
+    }
+    state = newState
+  }
+  return state
+}

--- a/src/hooks/useMatchmaking.ts
+++ b/src/hooks/useMatchmaking.ts
@@ -1,0 +1,404 @@
+/**
+ * Custom React hook for managing online matchmaking and game state
+ *
+ * Handles:
+ * - Joining/leaving matchmaking queue
+ * - Polling for match status
+ * - Polling for game state updates
+ * - Submitting moves
+ * - Resigning games
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { useAuthenticatedApi } from './useAuthenticatedApi'
+import type { Board } from '../game/makefour'
+
+export type MatchmakingMode = 'ranked' | 'casual'
+
+export type MatchmakingStatus =
+  | 'idle'
+  | 'joining'
+  | 'queued'
+  | 'matched'
+  | 'playing'
+  | 'completed'
+  | 'error'
+
+export interface OnlineGameState {
+  id: string
+  playerNumber: 1 | 2
+  currentTurn: 1 | 2
+  moves: number[]
+  board: Board | null
+  status: 'active' | 'completed' | 'abandoned'
+  winner: '1' | '2' | 'draw' | null
+  mode: MatchmakingMode
+  opponentRating: number
+  isYourTurn: boolean
+  lastMoveAt: number
+}
+
+interface MatchmakingState {
+  status: MatchmakingStatus
+  error: string | null
+  waitTime: number
+  currentTolerance: number
+  mode: MatchmakingMode
+  game: OnlineGameState | null
+}
+
+const QUEUE_POLL_INTERVAL = 2000 // 2 seconds
+const GAME_POLL_INTERVAL = 500 // 500ms for responsive gameplay
+
+export function useMatchmaking() {
+  const { apiCall } = useAuthenticatedApi()
+  const [state, setState] = useState<MatchmakingState>({
+    status: 'idle',
+    error: null,
+    waitTime: 0,
+    currentTolerance: 100,
+    mode: 'ranked',
+    game: null,
+  })
+
+  const queuePollRef = useRef<NodeJS.Timeout | null>(null)
+  const gamePollRef = useRef<NodeJS.Timeout | null>(null)
+  const isMountedRef = useRef(true)
+
+  // Cleanup on unmount
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      if (queuePollRef.current) {
+        clearInterval(queuePollRef.current)
+      }
+      if (gamePollRef.current) {
+        clearInterval(gamePollRef.current)
+      }
+    }
+  }, [])
+
+  /**
+   * Join the matchmaking queue
+   */
+  const joinQueue = useCallback(
+    async (mode: MatchmakingMode = 'ranked') => {
+      setState((prev) => ({ ...prev, status: 'joining', error: null, mode }))
+
+      try {
+        await apiCall('/api/matchmaking/join', {
+          method: 'POST',
+          body: JSON.stringify({ mode }),
+        })
+
+        if (!isMountedRef.current) return
+
+        setState((prev) => ({
+          ...prev,
+          status: 'queued',
+          waitTime: 0,
+        }))
+
+        // Start polling for match status
+        startQueuePolling()
+      } catch (error) {
+        if (!isMountedRef.current) return
+        setState((prev) => ({
+          ...prev,
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Failed to join queue',
+        }))
+      }
+    },
+    [apiCall]
+  )
+
+  /**
+   * Leave the matchmaking queue
+   */
+  const leaveQueue = useCallback(async () => {
+    // Stop polling first
+    if (queuePollRef.current) {
+      clearInterval(queuePollRef.current)
+      queuePollRef.current = null
+    }
+
+    try {
+      await apiCall('/api/matchmaking/leave', { method: 'POST' })
+    } catch {
+      // Ignore errors when leaving queue
+    }
+
+    if (!isMountedRef.current) return
+
+    setState({
+      status: 'idle',
+      error: null,
+      waitTime: 0,
+      currentTolerance: 100,
+      mode: 'ranked',
+      game: null,
+    })
+  }, [apiCall])
+
+  /**
+   * Poll for matchmaking status
+   */
+  const pollQueueStatus = useCallback(async () => {
+    try {
+      const response = await apiCall<{
+        status: 'queued' | 'matched' | 'not_queued'
+        gameId?: string
+        playerNumber?: 1 | 2
+        waitTime?: number
+        currentTolerance?: number
+        mode?: MatchmakingMode
+        opponent?: { rating: number }
+      }>('/api/matchmaking/status')
+
+      if (!isMountedRef.current) return
+
+      if (response.status === 'matched' && response.gameId) {
+        // Stop queue polling
+        if (queuePollRef.current) {
+          clearInterval(queuePollRef.current)
+          queuePollRef.current = null
+        }
+
+        setState((prev) => ({
+          ...prev,
+          status: 'matched',
+        }))
+
+        // Fetch initial game state and start game polling
+        await fetchGameState(response.gameId)
+      } else if (response.status === 'queued') {
+        setState((prev) => ({
+          ...prev,
+          waitTime: response.waitTime || 0,
+          currentTolerance: response.currentTolerance || prev.currentTolerance,
+        }))
+      } else if (response.status === 'not_queued') {
+        // User was removed from queue (shouldn't happen normally)
+        if (queuePollRef.current) {
+          clearInterval(queuePollRef.current)
+          queuePollRef.current = null
+        }
+        setState((prev) => ({
+          ...prev,
+          status: 'idle',
+          error: 'Removed from queue',
+        }))
+      }
+    } catch (error) {
+      // Don't set error state for transient polling failures
+      console.error('Queue poll error:', error)
+    }
+  }, [apiCall])
+
+  /**
+   * Start polling for queue status
+   */
+  const startQueuePolling = useCallback(() => {
+    if (queuePollRef.current) {
+      clearInterval(queuePollRef.current)
+    }
+
+    // Poll immediately, then on interval
+    pollQueueStatus()
+    queuePollRef.current = setInterval(pollQueueStatus, QUEUE_POLL_INTERVAL)
+  }, [pollQueueStatus])
+
+  /**
+   * Fetch game state
+   */
+  const fetchGameState = useCallback(
+    async (gameId: string) => {
+      try {
+        const response = await apiCall<OnlineGameState>(`/api/match/${gameId}`)
+
+        if (!isMountedRef.current) return
+
+        setState((prev) => ({
+          ...prev,
+          status: response.status === 'completed' ? 'completed' : 'playing',
+          game: response,
+        }))
+
+        // Start game polling if game is active
+        if (response.status === 'active') {
+          startGamePolling(gameId)
+        } else {
+          // Stop polling if game is over
+          if (gamePollRef.current) {
+            clearInterval(gamePollRef.current)
+            gamePollRef.current = null
+          }
+        }
+      } catch (error) {
+        if (!isMountedRef.current) return
+        setState((prev) => ({
+          ...prev,
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Failed to fetch game',
+        }))
+      }
+    },
+    [apiCall]
+  )
+
+  /**
+   * Start polling for game state
+   */
+  const startGamePolling = useCallback(
+    (gameId: string) => {
+      if (gamePollRef.current) {
+        clearInterval(gamePollRef.current)
+      }
+
+      gamePollRef.current = setInterval(async () => {
+        try {
+          const response = await apiCall<OnlineGameState>(`/api/match/${gameId}`)
+
+          if (!isMountedRef.current) return
+
+          setState((prev) => ({
+            ...prev,
+            status: response.status === 'completed' ? 'completed' : 'playing',
+            game: response,
+          }))
+
+          // Stop polling if game is over
+          if (response.status !== 'active') {
+            if (gamePollRef.current) {
+              clearInterval(gamePollRef.current)
+              gamePollRef.current = null
+            }
+          }
+        } catch (error) {
+          console.error('Game poll error:', error)
+        }
+      }, GAME_POLL_INTERVAL)
+    },
+    [apiCall]
+  )
+
+  /**
+   * Submit a move
+   */
+  const submitMove = useCallback(
+    async (column: number) => {
+      if (!state.game) return false
+
+      try {
+        const response = await apiCall<{
+          success: boolean
+          moves: number[]
+          board: Board
+          currentTurn: 1 | 2
+          status: 'active' | 'completed'
+          winner: '1' | '2' | 'draw' | null
+          isYourTurn: boolean
+        }>(`/api/match/${state.game.id}`, {
+          method: 'POST',
+          body: JSON.stringify({ column }),
+        })
+
+        if (!isMountedRef.current) return false
+
+        setState((prev) => ({
+          ...prev,
+          status: response.status === 'completed' ? 'completed' : 'playing',
+          game: prev.game
+            ? {
+                ...prev.game,
+                moves: response.moves,
+                board: response.board,
+                currentTurn: response.currentTurn,
+                status: response.status,
+                winner: response.winner,
+                isYourTurn: response.isYourTurn,
+              }
+            : null,
+        }))
+
+        return true
+      } catch (error) {
+        console.error('Move submission error:', error)
+        return false
+      }
+    },
+    [apiCall, state.game]
+  )
+
+  /**
+   * Resign from current game
+   */
+  const resign = useCallback(async () => {
+    if (!state.game) return
+
+    // Stop game polling
+    if (gamePollRef.current) {
+      clearInterval(gamePollRef.current)
+      gamePollRef.current = null
+    }
+
+    try {
+      const response = await apiCall<{
+        success: boolean
+        status: 'completed'
+        winner: '1' | '2'
+        resigned: boolean
+      }>(`/api/match/${state.game.id}/resign`, { method: 'POST' })
+
+      if (!isMountedRef.current) return
+
+      setState((prev) => ({
+        ...prev,
+        status: 'completed',
+        game: prev.game
+          ? {
+              ...prev.game,
+              status: 'completed',
+              winner: response.winner,
+            }
+          : null,
+      }))
+    } catch (error) {
+      console.error('Resign error:', error)
+    }
+  }, [apiCall, state.game])
+
+  /**
+   * Reset to idle state
+   */
+  const reset = useCallback(() => {
+    if (queuePollRef.current) {
+      clearInterval(queuePollRef.current)
+      queuePollRef.current = null
+    }
+    if (gamePollRef.current) {
+      clearInterval(gamePollRef.current)
+      gamePollRef.current = null
+    }
+
+    setState({
+      status: 'idle',
+      error: null,
+      waitTime: 0,
+      currentTolerance: 100,
+      mode: 'ranked',
+      game: null,
+    })
+  }, [])
+
+  return {
+    ...state,
+    joinQueue,
+    leaveQueue,
+    submitMove,
+    resign,
+    reset,
+  }
+}


### PR DESCRIPTION
## Summary

- Adds online matchmaking system for finding and playing against real opponents
- Implements rating-based matchmaking with expanding tolerance over time
- Supports both ranked (affects ELO) and casual match types
- Real-time game synchronization via polling (500ms intervals)
- Server-side move validation to prevent cheating

## Changes

### Database (`schema.sql`)
- Added `matchmaking_queue` table for players waiting for matches
- Added `active_games` table for games in progress

### API Endpoints
- `POST /api/matchmaking/join` - Join the matchmaking queue
- `POST /api/matchmaking/leave` - Leave the matchmaking queue  
- `GET /api/matchmaking/status` - Poll for match status (handles matching)
- `GET /api/match/:id` - Get current game state
- `POST /api/match/:id` - Submit a move
- `POST /api/match/:id/resign` - Resign from game

### Frontend
- Added `useMatchmaking` hook for state management and polling
- Extended PlayPage with online game mode option
- Added matchmaking queue UI with wait time and tolerance display
- Added online game screen with real-time updates

## Test plan

- [ ] Join matchmaking queue and verify queue status polling
- [ ] Match two players and verify game creation
- [ ] Submit moves and verify real-time sync (<500ms latency)
- [ ] Test resignation and verify ELO updates
- [ ] Test ranked vs casual mode differences
- [ ] Verify graceful handling of disconnections

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)