### PR TITLE
feat: add user profile page with statistics and account management

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,13 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [
-      "node_modules",
-      "dist",
-      ".wrangler",
-      "backups",
-      "*.log"
-    ]
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/.wrangler", "!**/backups", "!**/*.log"]
   },
   "formatter": {
     "enabled": true,
@@ -46,7 +40,5 @@
       "arrowParentheses": "always"
     }
   },
-  "organizeImports": {
-    "enabled": true
-  }
+  "assist": { "actions": { "source": { "organizeImports": "on" } } }
 }

--- a/functions/api/users/me.ts
+++ b/functions/api/users/me.ts
@@ -1,0 +1,76 @@
+import { validateSession, errorResponse, jsonResponse } from '../../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+/**
+ * DELETE /api/users/me - Delete user account
+ *
+ * Permanently deletes the user's account and all associated data:
+ * - User record
+ * - Session tokens
+ * - Games
+ * - Rating history
+ * - Matchmaking queue entries
+ * - Active games (as forfeit)
+ */
+export async function onRequestDelete(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    // Validate session
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    const userId = session.userId
+
+    // Check if user exists
+    const user = await DB.prepare('SELECT id FROM users WHERE id = ?')
+      .bind(userId)
+      .first()
+
+    if (!user) {
+      return errorResponse('User not found', 404)
+    }
+
+    // Handle any active games (forfeit them)
+    const activeGamesResult = await DB.prepare(
+      `SELECT id, player1_id, player2_id FROM active_games
+       WHERE (player1_id = ? OR player2_id = ?) AND status = 'active'`
+    )
+      .bind(userId, userId)
+      .all()
+
+    const activeGames = activeGamesResult.results || []
+
+    for (const game of activeGames) {
+      // Mark game as abandoned with the other player winning
+      const winner = game.player1_id === userId ? '2' : '1'
+      await DB.prepare(
+        `UPDATE active_games SET status = 'abandoned', winner = ?, updated_at = ? WHERE id = ?`
+      )
+        .bind(winner, Date.now(), game.id)
+        .run()
+    }
+
+    // Delete user - CASCADE will handle related records
+    // Due to ON DELETE CASCADE, this will also delete:
+    // - session_tokens
+    // - email_verification_tokens
+    // - password_reset_tokens
+    // - games
+    // - rating_history
+    // - matchmaking_queue entries
+    await DB.prepare('DELETE FROM users WHERE id = ?')
+      .bind(userId)
+      .run()
+
+    return jsonResponse({ message: 'Account deleted successfully' })
+  } catch (error) {
+    console.error('Delete account error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}

--- a/functions/api/users/me/password.ts
+++ b/functions/api/users/me/password.ts
@@ -1,0 +1,105 @@
+import { validateSession, errorResponse, jsonResponse } from '../../../lib/auth'
+import { validateChangePasswordRequest } from '../../../../src/lib/schemas/auth'
+import bcrypt from 'bcryptjs'
+
+interface Env {
+  DB: D1Database
+}
+
+interface UserRow {
+  id: string
+  password_hash: string | null
+  oauth_provider: string | null
+}
+
+/**
+ * PUT /api/users/me/password - Change user password
+ *
+ * Request body:
+ * - old_password: Current password
+ * - new_password: New password (min 8 characters)
+ *
+ * Note: OAuth users cannot change password through this endpoint
+ */
+export async function onRequestPut(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    // Validate session
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    const userId = session.userId
+
+    // Parse and validate request body
+    let body: unknown
+    try {
+      body = await context.request.json()
+    } catch {
+      return errorResponse('Invalid JSON body', 400)
+    }
+
+    let validatedData: { old_password: string; new_password: string }
+    try {
+      validatedData = validateChangePasswordRequest(body)
+    } catch (e) {
+      return errorResponse(e instanceof Error ? e.message : 'Invalid request data', 400)
+    }
+
+    const { old_password, new_password } = validatedData
+
+    // Get user with password info
+    const user = await DB.prepare(
+      'SELECT id, password_hash, oauth_provider FROM users WHERE id = ?'
+    )
+      .bind(userId)
+      .first<UserRow>()
+
+    if (!user) {
+      return errorResponse('User not found', 404)
+    }
+
+    // Check if user uses OAuth (no password)
+    if (user.oauth_provider && !user.password_hash) {
+      return errorResponse(
+        'Cannot change password for OAuth accounts. Please manage your password through your OAuth provider.',
+        400
+      )
+    }
+
+    if (!user.password_hash) {
+      return errorResponse('No password set for this account', 400)
+    }
+
+    // Verify old password
+    const isValidPassword = await bcrypt.compare(old_password, user.password_hash)
+    if (!isValidPassword) {
+      return errorResponse('Current password is incorrect', 401)
+    }
+
+    // Hash new password
+    const newPasswordHash = await bcrypt.hash(new_password, 10)
+
+    // Update password
+    await DB.prepare(
+      'UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?'
+    )
+      .bind(newPasswordHash, Date.now(), userId)
+      .run()
+
+    // Optionally: Invalidate all other sessions for security
+    // Keep current session active
+    await DB.prepare(
+      'DELETE FROM session_tokens WHERE user_id = ? AND id != ?'
+    )
+      .bind(userId, session.sessionId)
+      .run()
+
+    return jsonResponse({ message: 'Password changed successfully' })
+  } catch (error) {
+    console.error('Change password error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}

--- a/functions/api/users/me/stats.ts
+++ b/functions/api/users/me/stats.ts
@@ -1,0 +1,214 @@
+import { validateSession, errorResponse, jsonResponse } from '../../../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+interface UserRow {
+  id: string
+  email: string
+  email_verified: number
+  oauth_provider: string | null
+  rating: number
+  games_played: number
+  wins: number
+  losses: number
+  draws: number
+  created_at: number
+  last_login: number
+  updated_at: number
+}
+
+interface GameRow {
+  outcome: string
+  player_number: number
+  opponent_type: string
+  move_count: number
+  rating_change: number
+  created_at: number
+}
+
+interface RatingHistoryRow {
+  rating_after: number
+  created_at: number
+}
+
+export async function onRequestGet(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    // Validate session
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    const userId = session.userId
+
+    // Get user data including oauth_provider
+    const user = await DB.prepare(
+      `SELECT id, email, email_verified, oauth_provider, rating, games_played, wins, losses, draws,
+              created_at, last_login, updated_at
+       FROM users WHERE id = ?`
+    )
+      .bind(userId)
+      .first<UserRow>()
+
+    if (!user) {
+      return errorResponse('User not found', 404)
+    }
+
+    // Get all games for stats calculation
+    const gamesResult = await DB.prepare(
+      `SELECT outcome, player_number, opponent_type, move_count, rating_change, created_at
+       FROM games WHERE user_id = ? ORDER BY created_at ASC`
+    )
+      .bind(userId)
+      .all<GameRow>()
+
+    const games = gamesResult.results || []
+
+    // Get rating history
+    const ratingHistoryResult = await DB.prepare(
+      `SELECT rating_after, created_at
+       FROM rating_history WHERE user_id = ? ORDER BY created_at ASC`
+    )
+      .bind(userId)
+      .all<RatingHistoryRow>()
+
+    const ratingHistory = ratingHistoryResult.results || []
+
+    // Calculate advanced stats
+    let peakRating = user.rating
+    let lowestRating = user.rating
+    let currentStreak = 0
+    let longestWinStreak = 0
+    let longestLossStreak = 0
+    let tempWinStreak = 0
+    let tempLossStreak = 0
+    let gamesAsPlayer1 = 0
+    let gamesAsPlayer2 = 0
+    let aiGames = 0
+    let humanGames = 0
+    let totalMoveCount = 0
+    let recentRatingChange = 0
+
+    // Process rating history for peak/lowest
+    for (const entry of ratingHistory) {
+      if (entry.rating_after > peakRating) peakRating = entry.rating_after
+      if (entry.rating_after < lowestRating) lowestRating = entry.rating_after
+    }
+
+    // If no history, use current rating
+    if (ratingHistory.length === 0) {
+      peakRating = 1200
+      lowestRating = 1200
+    }
+
+    // Process games for other stats
+    for (const game of games) {
+      // Player number stats
+      if (game.player_number === 1) gamesAsPlayer1++
+      else gamesAsPlayer2++
+
+      // Opponent type stats
+      if (game.opponent_type === 'ai') aiGames++
+      else humanGames++
+
+      // Move count
+      totalMoveCount += game.move_count
+
+      // Streak calculation
+      if (game.outcome === 'win') {
+        tempWinStreak++
+        tempLossStreak = 0
+        if (tempWinStreak > longestWinStreak) longestWinStreak = tempWinStreak
+      } else if (game.outcome === 'loss') {
+        tempLossStreak++
+        tempWinStreak = 0
+        if (tempLossStreak > longestLossStreak) longestLossStreak = tempLossStreak
+      } else {
+        // Draw breaks streaks
+        tempWinStreak = 0
+        tempLossStreak = 0
+      }
+    }
+
+    // Current streak (from most recent games)
+    if (games.length > 0) {
+      const recentGames = [...games].reverse()
+      let streakType: 'win' | 'loss' | null = null
+      currentStreak = 0
+
+      for (const game of recentGames) {
+        if (game.outcome === 'win') {
+          if (streakType === null) streakType = 'win'
+          if (streakType === 'win') currentStreak++
+          else break
+        } else if (game.outcome === 'loss') {
+          if (streakType === null) streakType = 'loss'
+          if (streakType === 'loss') currentStreak++
+          else break
+        } else {
+          break // Draw breaks streak
+        }
+      }
+
+      // Negative for loss streak
+      if (streakType === 'loss') currentStreak = -currentStreak
+    }
+
+    // Recent rating change (last 10 games)
+    const recentGames = games.slice(-10)
+    recentRatingChange = recentGames.reduce((sum, game) => sum + (game.rating_change || 0), 0)
+
+    // Determine rating trend
+    let ratingTrend: 'improving' | 'declining' | 'stable' = 'stable'
+    if (recentRatingChange > 20) ratingTrend = 'improving'
+    else if (recentRatingChange < -20) ratingTrend = 'declining'
+
+    // Calculate average move count
+    const avgMoveCount = games.length > 0 ? totalMoveCount / games.length : 0
+
+    // Format rating history for chart
+    const formattedRatingHistory = ratingHistory.map(entry => ({
+      rating: entry.rating_after,
+      createdAt: entry.created_at,
+    }))
+
+    return jsonResponse({
+      user: {
+        id: user.id,
+        email: user.email,
+        email_verified: user.email_verified === 1,
+        oauth_provider: user.oauth_provider,
+        rating: user.rating,
+        gamesPlayed: user.games_played,
+        wins: user.wins,
+        losses: user.losses,
+        draws: user.draws,
+        createdAt: user.created_at,
+        lastLogin: user.last_login,
+        updatedAt: user.updated_at,
+      },
+      stats: {
+        peakRating,
+        lowestRating,
+        currentStreak,
+        longestWinStreak,
+        longestLossStreak,
+        avgMoveCount,
+        gamesAsPlayer1,
+        gamesAsPlayer2,
+        aiGames,
+        humanGames,
+        ratingTrend,
+        recentRatingChange,
+      },
+      ratingHistory: formattedRatingHistory,
+    })
+  } catch (error) {
+    console.error('Stats endpoint error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import GamesPage from './pages/GamesPage'
 import ReplayPage from './pages/ReplayPage'
 import LeaderboardPage from './pages/LeaderboardPage'
 import SpectatorPage from './pages/SpectatorPage'
+import ProfilePage from './pages/ProfilePage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
@@ -56,6 +57,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <LeaderboardPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/profile"
+              element={
+                <ProtectedRoute>
+                  <ProfilePage />
                 </ProtectedRoute>
               }
             />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -23,6 +23,9 @@ export default function DashboardPage() {
             )}
           </div>
           <div className="flex gap-2">
+            <Link to="/profile">
+              <Button variant="ghost" size="sm">Profile</Button>
+            </Link>
             <ThemeToggle />
             <Button variant="outline" onClick={logout} size="sm">
               Logout

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,0 +1,636 @@
+import { useState, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi'
+import { Button } from '../components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import { Input } from '../components/ui/input'
+import ThemeToggle from '../components/ThemeToggle'
+
+interface UserStats {
+  user: {
+    id: string
+    email: string
+    email_verified: boolean
+    oauth_provider: string | null
+    rating: number
+    gamesPlayed: number
+    wins: number
+    losses: number
+    draws: number
+    createdAt: number
+    lastLogin: number
+    updatedAt: number
+  }
+  stats: {
+    peakRating: number
+    lowestRating: number
+    currentStreak: number
+    longestWinStreak: number
+    longestLossStreak: number
+    avgMoveCount: number
+    gamesAsPlayer1: number
+    gamesAsPlayer2: number
+    aiGames: number
+    humanGames: number
+    ratingTrend: 'improving' | 'declining' | 'stable'
+    recentRatingChange: number
+  }
+  ratingHistory: Array<{
+    rating: number
+    createdAt: number
+  }>
+}
+
+type TabType = 'overview' | 'statistics' | 'security' | 'settings'
+
+export default function ProfilePage() {
+  const { logout, user } = useAuth()
+  const { apiCall } = useAuthenticatedApi()
+  const navigate = useNavigate()
+
+  const [activeTab, setActiveTab] = useState<TabType>('overview')
+  const [stats, setStats] = useState<UserStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Password change state
+  const [oldPassword, setOldPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [passwordError, setPasswordError] = useState<string | null>(null)
+  const [passwordSuccess, setPasswordSuccess] = useState(false)
+  const [changingPassword, setChangingPassword] = useState(false)
+
+  // Delete account state
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [deleteConfirmText, setDeleteConfirmText] = useState('')
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        setLoading(true)
+        const data = await apiCall<UserStats>('/api/users/me/stats')
+        setStats(data)
+        setError(null)
+      } catch (err) {
+        setError('Failed to load profile data')
+        console.error('Failed to fetch stats:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchStats()
+  }, [apiCall])
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setPasswordError(null)
+    setPasswordSuccess(false)
+
+    if (newPassword !== confirmPassword) {
+      setPasswordError('Passwords do not match')
+      return
+    }
+
+    if (newPassword.length < 8) {
+      setPasswordError('New password must be at least 8 characters')
+      return
+    }
+
+    try {
+      setChangingPassword(true)
+      await apiCall('/api/users/me/password', {
+        method: 'PUT',
+        body: JSON.stringify({
+          old_password: oldPassword,
+          new_password: newPassword,
+        }),
+      })
+      setPasswordSuccess(true)
+      setOldPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    } catch (err) {
+      setPasswordError(err instanceof Error ? err.message : 'Failed to change password')
+    } finally {
+      setChangingPassword(false)
+    }
+  }
+
+  const handleDeleteAccount = async () => {
+    if (deleteConfirmText !== 'DELETE') return
+
+    try {
+      setDeleting(true)
+      await apiCall('/api/users/me', {
+        method: 'DELETE',
+      })
+      await logout()
+      navigate('/login')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete account')
+      setDeleting(false)
+    }
+  }
+
+  const winRate = user && user.gamesPlayed > 0
+    ? Math.round((user.wins / user.gamesPlayed) * 100)
+    : 0
+
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  const formatDateTime = (timestamp: number) => {
+    return new Date(timestamp).toLocaleString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  const tabs: Array<{ id: TabType; label: string }> = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'statistics', label: 'Statistics' },
+    { id: 'security', label: 'Security' },
+    { id: 'settings', label: 'Settings' },
+  ]
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <header className="border-b bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+        <div className="container mx-auto px-4 py-4 flex justify-between items-center">
+          <div>
+            <h1 className="text-2xl font-bold">Profile</h1>
+            {user && (
+              <p className="text-xs text-muted-foreground">{user.email}</p>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Link to="/dashboard">
+              <Button variant="outline" size="sm">Dashboard</Button>
+            </Link>
+            <ThemeToggle />
+            <Button variant="outline" onClick={logout} size="sm">
+              Logout
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-8">
+        {/* Tab Navigation */}
+        <div className="flex gap-1 mb-6 bg-muted/50 p-1 rounded-lg w-fit">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                activeTab === tab.id
+                  ? 'bg-white dark:bg-gray-800 shadow-sm'
+                  : 'hover:bg-white/50 dark:hover:bg-gray-800/50'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {loading && (
+          <Card>
+            <CardContent className="py-8 text-center">
+              <div className="animate-pulse">Loading profile data...</div>
+            </CardContent>
+          </Card>
+        )}
+
+        {error && !loading && (
+          <Card>
+            <CardContent className="py-8 text-center text-red-600 dark:text-red-400">
+              {error}
+            </CardContent>
+          </Card>
+        )}
+
+        {!loading && !error && stats && (
+          <>
+            {/* Overview Tab */}
+            {activeTab === 'overview' && (
+              <div className="space-y-6">
+                {/* Profile Info Card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Account Information</CardTitle>
+                    <CardDescription>Your account details and status</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <div>
+                        <span className="block text-sm text-muted-foreground">Email</span>
+                        <p className="font-medium">{stats.user.email}</p>
+                      </div>
+                      <div>
+                        <span className="block text-sm text-muted-foreground">Email Status</span>
+                        <p className="font-medium">
+                          {stats.user.email_verified ? (
+                            <span className="text-green-600 dark:text-green-400">Verified</span>
+                          ) : (
+                            <span className="text-yellow-600 dark:text-yellow-400">Unverified</span>
+                          )}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="block text-sm text-muted-foreground">Member Since</span>
+                        <p className="font-medium">{formatDate(stats.user.createdAt)}</p>
+                      </div>
+                      <div>
+                        <span className="block text-sm text-muted-foreground">Last Login</span>
+                        <p className="font-medium">{formatDateTime(stats.user.lastLogin)}</p>
+                      </div>
+                      {stats.user.oauth_provider && (
+                        <div>
+                          <span className="block text-sm text-muted-foreground">Linked Account</span>
+                          <p className="font-medium capitalize">{stats.user.oauth_provider}</p>
+                        </div>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Quick Stats Card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Performance Summary</CardTitle>
+                    <CardDescription>Your current rating and game statistics</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex flex-wrap gap-6 items-center">
+                      <div className="text-center">
+                        <div className="text-4xl font-bold text-primary">{stats.user.rating}</div>
+                        <div className="text-sm text-muted-foreground">Rating</div>
+                        {stats.stats.ratingTrend !== 'stable' && (
+                          <div className={`text-xs ${
+                            stats.stats.ratingTrend === 'improving'
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-red-600 dark:text-red-400'
+                          }`}>
+                            {stats.stats.ratingTrend === 'improving' ? '↑' : '↓'} {stats.stats.ratingTrend}
+                          </div>
+                        )}
+                      </div>
+                      <div className="h-16 w-px bg-border hidden sm:block" />
+                      <div className="flex gap-6 text-center">
+                        <div>
+                          <div className="text-2xl font-semibold">{stats.user.gamesPlayed}</div>
+                          <div className="text-sm text-muted-foreground">Games</div>
+                        </div>
+                        <div>
+                          <div className="text-2xl font-semibold text-green-600 dark:text-green-400">{stats.user.wins}</div>
+                          <div className="text-sm text-muted-foreground">Wins</div>
+                        </div>
+                        <div>
+                          <div className="text-2xl font-semibold text-red-600 dark:text-red-400">{stats.user.losses}</div>
+                          <div className="text-sm text-muted-foreground">Losses</div>
+                        </div>
+                        <div>
+                          <div className="text-2xl font-semibold text-yellow-600 dark:text-yellow-400">{stats.user.draws}</div>
+                          <div className="text-sm text-muted-foreground">Draws</div>
+                        </div>
+                        <div>
+                          <div className="text-2xl font-semibold">{winRate}%</div>
+                          <div className="text-sm text-muted-foreground">Win Rate</div>
+                        </div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+
+            {/* Statistics Tab */}
+            {activeTab === 'statistics' && (
+              <div className="space-y-6">
+                {/* Rating Stats */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Rating Statistics</CardTitle>
+                    <CardDescription>Your rating progression and records</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold text-primary">{stats.user.rating}</div>
+                        <div className="text-sm text-muted-foreground">Current Rating</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold text-green-600 dark:text-green-400">{stats.stats.peakRating}</div>
+                        <div className="text-sm text-muted-foreground">Peak Rating</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold text-red-600 dark:text-red-400">{stats.stats.lowestRating}</div>
+                        <div className="text-sm text-muted-foreground">Lowest Rating</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className={`text-2xl font-bold ${
+                          stats.stats.recentRatingChange >= 0
+                            ? 'text-green-600 dark:text-green-400'
+                            : 'text-red-600 dark:text-red-400'
+                        }`}>
+                          {stats.stats.recentRatingChange >= 0 ? '+' : ''}{stats.stats.recentRatingChange}
+                        </div>
+                        <div className="text-sm text-muted-foreground">Recent Change</div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Streak Stats */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Streaks</CardTitle>
+                    <CardDescription>Your win and loss streaks</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className={`text-2xl font-bold ${
+                          stats.stats.currentStreak >= 0
+                            ? 'text-green-600 dark:text-green-400'
+                            : 'text-red-600 dark:text-red-400'
+                        }`}>
+                          {stats.stats.currentStreak >= 0 ? `W${stats.stats.currentStreak}` : `L${Math.abs(stats.stats.currentStreak)}`}
+                        </div>
+                        <div className="text-sm text-muted-foreground">Current Streak</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold text-green-600 dark:text-green-400">{stats.stats.longestWinStreak}</div>
+                        <div className="text-sm text-muted-foreground">Best Win Streak</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold text-red-600 dark:text-red-400">{stats.stats.longestLossStreak}</div>
+                        <div className="text-sm text-muted-foreground">Worst Loss Streak</div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Game Breakdown */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Game Breakdown</CardTitle>
+                    <CardDescription>Analysis of your games</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold">{stats.stats.aiGames}</div>
+                        <div className="text-sm text-muted-foreground">vs AI</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold">{stats.stats.humanGames}</div>
+                        <div className="text-sm text-muted-foreground">vs Human</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold">{stats.stats.gamesAsPlayer1}</div>
+                        <div className="text-sm text-muted-foreground">As Red (1st)</div>
+                      </div>
+                      <div className="text-center p-4 bg-muted/50 rounded-lg">
+                        <div className="text-2xl font-bold">{stats.stats.gamesAsPlayer2}</div>
+                        <div className="text-sm text-muted-foreground">As Yellow (2nd)</div>
+                      </div>
+                    </div>
+                    {stats.stats.avgMoveCount > 0 && (
+                      <div className="mt-4 text-center text-sm text-muted-foreground">
+                        Average game length: <span className="font-medium">{stats.stats.avgMoveCount.toFixed(1)} moves</span>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+
+                {/* Rating History Chart (Simple visualization) */}
+                {stats.ratingHistory.length > 0 && (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Rating History</CardTitle>
+                      <CardDescription>Your last {stats.ratingHistory.length} games</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="h-32 flex items-end gap-1">
+                        {stats.ratingHistory.slice(-20).map((entry, index) => {
+                          const min = Math.min(...stats.ratingHistory.map(e => e.rating))
+                          const max = Math.max(...stats.ratingHistory.map(e => e.rating))
+                          const range = max - min || 1
+                          const height = ((entry.rating - min) / range) * 100
+                          return (
+                            <div
+                              key={index}
+                              className="flex-1 bg-primary/60 hover:bg-primary rounded-t transition-colors"
+                              style={{ height: `${Math.max(height, 5)}%` }}
+                              title={`${entry.rating} - ${formatDate(entry.createdAt)}`}
+                            />
+                          )
+                        })}
+                      </div>
+                      <div className="flex justify-between mt-2 text-xs text-muted-foreground">
+                        <span>Oldest</span>
+                        <span>Most Recent</span>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
+              </div>
+            )}
+
+            {/* Security Tab */}
+            {activeTab === 'security' && (
+              <div className="space-y-6">
+                {/* Change Password Card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Change Password</CardTitle>
+                    <CardDescription>
+                      {stats.user.oauth_provider
+                        ? `You signed in with ${stats.user.oauth_provider}. Password change is not available for OAuth accounts.`
+                        : 'Update your password to keep your account secure'}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    {stats.user.oauth_provider ? (
+                      <p className="text-muted-foreground">
+                        Your account is linked to {stats.user.oauth_provider}. Manage your password through your {stats.user.oauth_provider} account settings.
+                      </p>
+                    ) : (
+                      <form onSubmit={handleChangePassword} className="space-y-4 max-w-md">
+                        {passwordError && (
+                          <div className="p-3 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-md text-sm">
+                            {passwordError}
+                          </div>
+                        )}
+                        {passwordSuccess && (
+                          <div className="p-3 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-md text-sm">
+                            Password changed successfully!
+                          </div>
+                        )}
+                        <div>
+                          <label htmlFor="current-password" className="block text-sm font-medium mb-1">Current Password</label>
+                          <Input
+                            id="current-password"
+                            type="password"
+                            value={oldPassword}
+                            onChange={(e) => setOldPassword(e.target.value)}
+                            required
+                          />
+                        </div>
+                        <div>
+                          <label htmlFor="new-password" className="block text-sm font-medium mb-1">New Password</label>
+                          <Input
+                            id="new-password"
+                            type="password"
+                            value={newPassword}
+                            onChange={(e) => setNewPassword(e.target.value)}
+                            required
+                            minLength={8}
+                          />
+                        </div>
+                        <div>
+                          <label htmlFor="confirm-password" className="block text-sm font-medium mb-1">Confirm New Password</label>
+                          <Input
+                            id="confirm-password"
+                            type="password"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            required
+                          />
+                        </div>
+                        <Button type="submit" disabled={changingPassword}>
+                          {changingPassword ? 'Changing...' : 'Change Password'}
+                        </Button>
+                      </form>
+                    )}
+                  </CardContent>
+                </Card>
+
+                {/* Linked Accounts Card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Linked Accounts</CardTitle>
+                    <CardDescription>External accounts connected to your profile</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+                      <div className="flex items-center gap-3">
+                        <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center shadow-sm">
+                          <svg className="w-5 h-5" viewBox="0 0 24 24" aria-labelledby="google-icon-title">
+                            <title id="google-icon-title">Google</title>
+                            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                          </svg>
+                        </div>
+                        <div>
+                          <p className="font-medium">Google</p>
+                          <p className="text-sm text-muted-foreground">
+                            {stats.user.oauth_provider === 'google' ? 'Connected' : 'Not connected'}
+                          </p>
+                        </div>
+                      </div>
+                      <Button variant="outline" size="sm" disabled>
+                        {stats.user.oauth_provider === 'google' ? 'Connected' : 'Connect'}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+
+            {/* Settings Tab */}
+            {activeTab === 'settings' && (
+              <div className="space-y-6">
+                {/* Danger Zone */}
+                <Card className="border-red-200 dark:border-red-800">
+                  <CardHeader>
+                    <CardTitle className="text-red-600 dark:text-red-400">Danger Zone</CardTitle>
+                    <CardDescription>Irreversible actions for your account</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="p-4 border border-red-200 dark:border-red-800 rounded-lg">
+                      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                        <div>
+                          <h4 className="font-medium">Delete Account</h4>
+                          <p className="text-sm text-muted-foreground">
+                            Permanently delete your account and all associated data. This action cannot be undone.
+                          </p>
+                        </div>
+                        <Button
+                          variant="destructive"
+                          onClick={() => setShowDeleteConfirm(true)}
+                        >
+                          Delete Account
+                        </Button>
+                      </div>
+                    </div>
+
+                    {showDeleteConfirm && (
+                      <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                        <h4 className="font-medium text-red-600 dark:text-red-400 mb-2">
+                          Are you absolutely sure?
+                        </h4>
+                        <p className="text-sm text-muted-foreground mb-4">
+                          This will permanently delete your account, all your games, statistics, and rating history.
+                          This action cannot be undone.
+                        </p>
+                        <div className="space-y-3">
+                          <div>
+                            <label htmlFor="delete-confirm" className="block text-sm font-medium mb-1">
+                              Type DELETE to confirm
+                            </label>
+                            <Input
+                              id="delete-confirm"
+                              value={deleteConfirmText}
+                              onChange={(e) => setDeleteConfirmText(e.target.value)}
+                              placeholder="DELETE"
+                              className="max-w-xs"
+                            />
+                          </div>
+                          <div className="flex gap-2">
+                            <Button
+                              variant="destructive"
+                              onClick={handleDeleteAccount}
+                              disabled={deleteConfirmText !== 'DELETE' || deleting}
+                            >
+                              {deleting ? 'Deleting...' : 'Delete My Account'}
+                            </Button>
+                            <Button
+                              variant="outline"
+                              onClick={() => {
+                                setShowDeleteConfirm(false)
+                                setDeleteConfirmText('')
+                              }}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Implements a comprehensive user profile page with tab-based layout (Overview, Statistics, Security, Settings)
- Adds API endpoints for user stats, password change, and account deletion
- Includes detailed game statistics display with rating history visualization
- Provides account management features including password change and account deletion

## Changes
### Frontend
- New `ProfilePage` component with tabs for different sections
- Profile link added to dashboard header navigation
- Route added at `/profile`

### Backend
- `GET /api/users/me/stats` - Returns detailed user statistics including:
  - Peak/lowest ratings
  - Current and longest win/loss streaks  
  - Game breakdown by opponent type and player position
  - Rating history for chart visualization
- `PUT /api/users/me/password` - Password change (non-OAuth accounts only)
- `DELETE /api/users/me` - Account deletion with cascade cleanup

## Screenshots
The profile page includes:
- **Overview tab**: Account info, performance summary with rating and win/loss/draw stats
- **Statistics tab**: Rating stats, streaks, game breakdown, rating history chart
- **Security tab**: Password change form, linked accounts display
- **Settings tab**: Account deletion with confirmation

## Test plan
- [ ] Build passes (`pnpm run build`)
- [ ] Tests pass (`pnpm run test`)
- [ ] Profile page loads at `/profile` route
- [ ] Tab navigation works correctly
- [ ] Statistics display correctly for users with game history
- [ ] Password change works for non-OAuth users
- [ ] Account deletion requires typing "DELETE" to confirm

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)