### PR TITLE
feat: add game statistics dashboard with interactive charts

### DIFF
--- a/functions/api/users/me/stats/history.ts
+++ b/functions/api/users/me/stats/history.ts
@@ -1,0 +1,265 @@
+import { validateSession, errorResponse, jsonResponse } from '../../../../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+interface GameRow {
+  id: string
+  outcome: string
+  player_number: number
+  opponent_type: string
+  ai_difficulty: string | null
+  move_count: number
+  moves: string
+  rating_change: number
+  created_at: number
+}
+
+interface DailyStats {
+  date: string
+  games: number
+  wins: number
+  losses: number
+  draws: number
+  ratingChange: number
+  avgMoveCount: number
+}
+
+interface OpeningStats {
+  column: number
+  games: number
+  wins: number
+  losses: number
+  draws: number
+  winRate: number
+}
+
+interface RecentGame {
+  id: string
+  outcome: string
+  opponentType: string
+  aiDifficulty: string | null
+  playerNumber: number
+  moveCount: number
+  ratingChange: number
+  createdAt: number
+  firstMove: number | null
+}
+
+export async function onRequestGet(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    const userId = session.userId
+    const url = new URL(context.request.url)
+
+    // Parse date range filters (timestamps in milliseconds)
+    const startDateParam = url.searchParams.get('start')
+    const endDateParam = url.searchParams.get('end')
+
+    // Default to last 30 days if no range specified
+    const now = Date.now()
+    const thirtyDaysAgo = now - 30 * 24 * 60 * 60 * 1000
+    const startDate = startDateParam ? Number.parseInt(startDateParam, 10) : thirtyDaysAgo
+    const endDate = endDateParam ? Number.parseInt(endDateParam, 10) : now
+
+    // Get games within date range
+    const gamesResult = await DB.prepare(
+      `SELECT id, outcome, player_number, opponent_type, ai_difficulty, move_count, moves, rating_change, created_at
+       FROM games
+       WHERE user_id = ? AND created_at >= ? AND created_at <= ?
+       ORDER BY created_at ASC`
+    )
+      .bind(userId, startDate, endDate)
+      .all<GameRow>()
+
+    const games = gamesResult.results || []
+
+    // Calculate daily aggregated stats
+    const dailyMap = new Map<string, DailyStats>()
+    const openingMap = new Map<number, { wins: number; losses: number; draws: number; games: number }>()
+
+    // Stats for wins vs losses analysis
+    let totalWinMoves = 0
+    let winCount = 0
+    let totalLossMoves = 0
+    let lossCount = 0
+
+    // Player position stats
+    let player1Wins = 0
+    let player1Games = 0
+    let player2Wins = 0
+    let player2Games = 0
+
+    for (const game of games) {
+      // Daily aggregation
+      const date = new Date(game.created_at).toISOString().split('T')[0]
+      const existing = dailyMap.get(date) || {
+        date,
+        games: 0,
+        wins: 0,
+        losses: 0,
+        draws: 0,
+        ratingChange: 0,
+        avgMoveCount: 0,
+      }
+
+      existing.games++
+      existing.ratingChange += game.rating_change || 0
+      existing.avgMoveCount += game.move_count
+
+      if (game.outcome === 'win') existing.wins++
+      else if (game.outcome === 'loss') existing.losses++
+      else existing.draws++
+
+      dailyMap.set(date, existing)
+
+      // Opening move stats (first move in the moves array)
+      try {
+        const moves = JSON.parse(game.moves) as number[]
+        if (moves.length > 0) {
+          const firstMove = game.player_number === 1 ? moves[0] : moves[1]
+          if (firstMove !== undefined) {
+            const openingStats = openingMap.get(firstMove) || { wins: 0, losses: 0, draws: 0, games: 0 }
+            openingStats.games++
+            if (game.outcome === 'win') openingStats.wins++
+            else if (game.outcome === 'loss') openingStats.losses++
+            else openingStats.draws++
+            openingMap.set(firstMove, openingStats)
+          }
+        }
+      } catch {
+        // Skip malformed moves
+      }
+
+      // Win/loss move count analysis
+      if (game.outcome === 'win') {
+        totalWinMoves += game.move_count
+        winCount++
+      } else if (game.outcome === 'loss') {
+        totalLossMoves += game.move_count
+        lossCount++
+      }
+
+      // Player position stats
+      if (game.player_number === 1) {
+        player1Games++
+        if (game.outcome === 'win') player1Wins++
+      } else {
+        player2Games++
+        if (game.outcome === 'win') player2Wins++
+      }
+    }
+
+    // Finalize daily averages
+    const dailyStats: DailyStats[] = []
+    for (const [, stats] of dailyMap) {
+      stats.avgMoveCount = stats.games > 0 ? Math.round((stats.avgMoveCount / stats.games) * 10) / 10 : 0
+      dailyStats.push(stats)
+    }
+    dailyStats.sort((a, b) => a.date.localeCompare(b.date))
+
+    // Calculate cumulative win rate over time
+    let cumulativeWins = 0
+    let cumulativeGames = 0
+    const winRateOverTime = dailyStats.map((day) => {
+      cumulativeWins += day.wins
+      cumulativeGames += day.games
+      return {
+        date: day.date,
+        winRate: cumulativeGames > 0 ? Math.round((cumulativeWins / cumulativeGames) * 1000) / 10 : 0,
+        games: cumulativeGames,
+      }
+    })
+
+    // Build opening stats sorted by games played
+    const openingStats: OpeningStats[] = []
+    for (const [column, stats] of openingMap) {
+      openingStats.push({
+        column,
+        games: stats.games,
+        wins: stats.wins,
+        losses: stats.losses,
+        draws: stats.draws,
+        winRate: stats.games > 0 ? Math.round((stats.wins / stats.games) * 1000) / 10 : 0,
+      })
+    }
+    openingStats.sort((a, b) => b.games - a.games)
+
+    // Recent games (last 10)
+    const recentGames: RecentGame[] = games.slice(-10).reverse().map((game) => {
+      let firstMove: number | null = null
+      try {
+        const moves = JSON.parse(game.moves) as number[]
+        if (moves.length > 0) {
+          firstMove = game.player_number === 1 ? moves[0] : (moves[1] ?? null)
+        }
+      } catch {
+        // Skip malformed moves
+      }
+      return {
+        id: game.id,
+        outcome: game.outcome,
+        opponentType: game.opponent_type,
+        aiDifficulty: game.ai_difficulty,
+        playerNumber: game.player_number,
+        moveCount: game.move_count,
+        ratingChange: game.rating_change,
+        createdAt: game.created_at,
+        firstMove,
+      }
+    })
+
+    // Calculate weekly aggregation
+    const weeklyMap = new Map<string, { games: number; wins: number; losses: number; draws: number }>()
+    for (const game of games) {
+      const date = new Date(game.created_at)
+      // Get ISO week number
+      const startOfYear = new Date(date.getFullYear(), 0, 1)
+      const weekNumber = Math.ceil(((date.getTime() - startOfYear.getTime()) / 86400000 + startOfYear.getDay() + 1) / 7)
+      const weekKey = `${date.getFullYear()}-W${weekNumber.toString().padStart(2, '0')}`
+
+      const existing = weeklyMap.get(weekKey) || { games: 0, wins: 0, losses: 0, draws: 0 }
+      existing.games++
+      if (game.outcome === 'win') existing.wins++
+      else if (game.outcome === 'loss') existing.losses++
+      else existing.draws++
+      weeklyMap.set(weekKey, existing)
+    }
+
+    const weeklyStats = Array.from(weeklyMap.entries())
+      .map(([week, stats]) => ({ week, ...stats }))
+      .sort((a, b) => a.week.localeCompare(b.week))
+
+    return jsonResponse({
+      dateRange: {
+        start: startDate,
+        end: endDate,
+      },
+      summary: {
+        totalGames: games.length,
+        wins: games.filter((g) => g.outcome === 'win').length,
+        losses: games.filter((g) => g.outcome === 'loss').length,
+        draws: games.filter((g) => g.outcome === 'draw').length,
+        avgMovesToWin: winCount > 0 ? Math.round((totalWinMoves / winCount) * 10) / 10 : 0,
+        avgMovesToLoss: lossCount > 0 ? Math.round((totalLossMoves / lossCount) * 10) / 10 : 0,
+        player1WinRate: player1Games > 0 ? Math.round((player1Wins / player1Games) * 1000) / 10 : 0,
+        player2WinRate: player2Games > 0 ? Math.round((player2Wins / player2Games) * 1000) / 10 : 0,
+      },
+      dailyStats,
+      weeklyStats,
+      winRateOverTime,
+      openingStats,
+      recentGames,
+    })
+  } catch (error) {
+    console.error('Stats history endpoint error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",
+    "recharts": "^3.6.0",
     "tailwind-merge": "^2.5.5",
     "zod": "^4.1.12"
   },
@@ -51,11 +52,11 @@
     "@vitejs/plugin-react": "^4.3.3",
     "autoprefixer": "^10.4.20",
     "bcryptjs": "^3.0.2",
-    "vitest": "^2.1.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
     "typescript": "~5.6.2",
     "vite": "^5.4.11",
+    "vitest": "^2.1.0",
     "wrangler": "^4.45.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-router-dom:
         specifier: ^6.28.0
         version: 6.30.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^3.6.0
+        version: 3.6.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.3)(react@18.3.1)(redux@5.0.1)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.0
@@ -710,6 +713,17 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@remix-run/router@1.23.1':
     resolution: {integrity: sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ==}
     engines: {node: '>=14.0.0'}
@@ -834,6 +848,12 @@ packages:
   '@speed-highlight/core@1.2.12':
     resolution: {integrity: sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -848,6 +868,33 @@ packages:
 
   '@types/bcryptjs@2.4.6':
     resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -865,6 +912,9 @@ packages:
 
   '@types/react@18.3.27':
     resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1018,6 +1068,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1026,6 +1120,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -1050,6 +1147,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-toolkit@1.43.0:
+    resolution: {integrity: sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -1066,6 +1166,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
@@ -1124,6 +1227,16 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.0.1:
+    resolution: {integrity: sha512-naDCyggtcBWANtIrjQEajhhBEuL9b0Zg4zmlWK2CzS6xCWSE39/vvf4LqnMjUAWHBhot4m9MHCM/Z+mfWhUkiA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
@@ -1323,6 +1436,21 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@19.2.3:
+    resolution: {integrity: sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==}
+
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -1350,6 +1478,25 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts@3.6.0:
+    resolution: {integrity: sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -1432,6 +1579,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1485,8 +1635,16 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -2053,6 +2211,18 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.0.1
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1)
+
   '@remix-run/router@1.23.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -2127,6 +2297,10 @@ snapshots:
 
   '@speed-highlight/core@1.2.12': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -2150,6 +2324,30 @@ snapshots:
 
   '@types/bcryptjs@2.4.6': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.3':
@@ -2166,6 +2364,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.3))':
     dependencies:
@@ -2323,9 +2523,49 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-eql@5.0.2: {}
 
@@ -2340,6 +2580,8 @@ snapshots:
   error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-toolkit@1.43.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2402,6 +2644,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventemitter3@5.0.1: {}
+
   exit-hook@2.2.1: {}
 
   expect-type@1.3.0: {}
@@ -2448,6 +2692,12 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  immer@10.2.0: {}
+
+  immer@11.0.1: {}
+
+  internmap@2.0.3: {}
 
   is-arrayish@0.3.4: {}
 
@@ -2605,6 +2855,17 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@19.2.3: {}
+
+  react-redux@9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      redux: 5.0.1
+
   react-refresh@0.17.0: {}
 
   react-router-dom@6.30.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -2630,6 +2891,34 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  recharts@3.6.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.3)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.43.0
+      eventemitter3: 5.0.1
+      immer: 10.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 19.2.3
+      react-redux: 9.2.0(@types/react@18.3.27)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
+  reselect@5.1.1: {}
 
   resolve@1.22.11:
     dependencies:
@@ -2771,6 +3060,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2811,7 +3102,28 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@2.1.9(@types/node@22.19.3):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ReplayPage from './pages/ReplayPage'
 import LeaderboardPage from './pages/LeaderboardPage'
 import SpectatorPage from './pages/SpectatorPage'
 import ProfilePage from './pages/ProfilePage'
+import StatsPage from './pages/StatsPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
@@ -65,6 +66,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <ProfilePage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/stats"
+              element={
+                <ProtectedRoute>
+                  <StatsPage />
                 </ProtectedRoute>
               }
             />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -23,6 +23,9 @@ export default function DashboardPage() {
             )}
           </div>
           <div className="flex gap-2">
+            <Link to="/stats">
+              <Button variant="ghost" size="sm">Stats</Button>
+            </Link>
             <Link to="/profile">
               <Button variant="ghost" size="sm">Profile</Button>
             </Link>
@@ -127,18 +130,20 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          {/* AI Coach Card (Coming Soon) */}
-          <Card className="hover:shadow-lg transition-shadow opacity-75">
+          {/* Statistics Card */}
+          <Card className="hover:shadow-lg transition-shadow">
             <CardHeader>
-              <CardTitle>AI Coach</CardTitle>
+              <CardTitle>Statistics</CardTitle>
               <CardDescription>
-                Get move suggestions and game analysis
+                View detailed analytics and trends
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <Button variant="secondary" className="w-full" size="lg" disabled>
-                Coming Soon
-              </Button>
+              <Link to="/stats">
+                <Button variant="outline" className="w-full" size="lg">
+                  View Stats
+                </Button>
+              </Link>
             </CardContent>
           </Card>
         </div>

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -1,0 +1,727 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi'
+import { Button } from '../components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import ThemeToggle from '../components/ThemeToggle'
+import {
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+} from 'recharts'
+
+interface UserStats {
+  user: {
+    rating: number
+    gamesPlayed: number
+    wins: number
+    losses: number
+    draws: number
+  }
+  stats: {
+    peakRating: number
+    lowestRating: number
+    currentStreak: number
+    longestWinStreak: number
+    longestLossStreak: number
+    ratingTrend: 'improving' | 'declining' | 'stable'
+    recentRatingChange: number
+  }
+  ratingHistory: Array<{
+    rating: number
+    createdAt: number
+  }>
+}
+
+interface StatsHistory {
+  dateRange: {
+    start: number
+    end: number
+  }
+  summary: {
+    totalGames: number
+    wins: number
+    losses: number
+    draws: number
+    avgMovesToWin: number
+    avgMovesToLoss: number
+    player1WinRate: number
+    player2WinRate: number
+  }
+  dailyStats: Array<{
+    date: string
+    games: number
+    wins: number
+    losses: number
+    draws: number
+    ratingChange: number
+    avgMoveCount: number
+  }>
+  weeklyStats: Array<{
+    week: string
+    games: number
+    wins: number
+    losses: number
+    draws: number
+  }>
+  winRateOverTime: Array<{
+    date: string
+    winRate: number
+    games: number
+  }>
+  openingStats: Array<{
+    column: number
+    games: number
+    wins: number
+    losses: number
+    draws: number
+    winRate: number
+  }>
+  recentGames: Array<{
+    id: string
+    outcome: string
+    opponentType: string
+    aiDifficulty: string | null
+    playerNumber: number
+    moveCount: number
+    ratingChange: number
+    createdAt: number
+    firstMove: number | null
+  }>
+}
+
+type DateRange = '7d' | '30d' | '90d' | 'all'
+
+const COLORS = {
+  wins: '#22c55e',
+  losses: '#ef4444',
+  draws: '#eab308',
+  primary: '#6366f1',
+}
+
+const COLUMN_NAMES = ['Far Left', 'Left', 'Mid-Left', 'Center', 'Mid-Right', 'Right', 'Far Right']
+
+export default function StatsPage() {
+  const { logout, user } = useAuth()
+  const { apiCall } = useAuthenticatedApi()
+
+  const [stats, setStats] = useState<UserStats | null>(null)
+  const [history, setHistory] = useState<StatsHistory | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [dateRange, setDateRange] = useState<DateRange>('30d')
+
+  const getDateRangeParams = useCallback((range: DateRange) => {
+    const now = Date.now()
+    switch (range) {
+      case '7d':
+        return { start: now - 7 * 24 * 60 * 60 * 1000, end: now }
+      case '30d':
+        return { start: now - 30 * 24 * 60 * 60 * 1000, end: now }
+      case '90d':
+        return { start: now - 90 * 24 * 60 * 60 * 1000, end: now }
+      case 'all':
+        return { start: 0, end: now }
+    }
+  }, [])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        const { start, end } = getDateRangeParams(dateRange)
+
+        const [statsData, historyData] = await Promise.all([
+          apiCall<UserStats>('/api/users/me/stats'),
+          apiCall<StatsHistory>(`/api/users/me/stats/history?start=${start}&end=${end}`),
+        ])
+
+        setStats(statsData)
+        setHistory(historyData)
+        setError(null)
+      } catch (err) {
+        setError('Failed to load statistics')
+        console.error('Failed to fetch stats:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [apiCall, dateRange, getDateRangeParams])
+
+  const exportCSV = () => {
+    if (!history) return
+
+    const rows = [
+      ['Date', 'Games', 'Wins', 'Losses', 'Draws', 'Rating Change', 'Avg Moves'],
+      ...history.dailyStats.map((day) => [
+        day.date,
+        day.games.toString(),
+        day.wins.toString(),
+        day.losses.toString(),
+        day.draws.toString(),
+        day.ratingChange.toString(),
+        day.avgMoveCount.toString(),
+      ]),
+    ]
+
+    const csv = rows.map((row) => row.join(',')).join('\n')
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `makefour-stats-${dateRange}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const winRate = user && user.gamesPlayed > 0 ? Math.round((user.wins / user.gamesPlayed) * 100) : 0
+
+  const pieData = history
+    ? [
+        { name: 'Wins', value: history.summary.wins, color: COLORS.wins },
+        { name: 'Losses', value: history.summary.losses, color: COLORS.losses },
+        { name: 'Draws', value: history.summary.draws, color: COLORS.draws },
+      ].filter((d) => d.value > 0)
+    : []
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <header className="border-b bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+        <div className="container mx-auto px-4 py-4 flex justify-between items-center">
+          <div>
+            <h1 className="text-2xl font-bold">Statistics</h1>
+            {user && <p className="text-xs text-muted-foreground">{user.email}</p>}
+          </div>
+          <div className="flex gap-2">
+            <Link to="/dashboard">
+              <Button variant="outline" size="sm">
+                Dashboard
+              </Button>
+            </Link>
+            <Link to="/profile">
+              <Button variant="outline" size="sm">
+                Profile
+              </Button>
+            </Link>
+            <ThemeToggle />
+            <Button variant="outline" onClick={logout} size="sm">
+              Logout
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-8">
+        {/* Date Range Filter */}
+        <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+          <div className="flex gap-1 bg-muted/50 p-1 rounded-lg">
+            {(['7d', '30d', '90d', 'all'] as DateRange[]).map((range) => (
+              <button
+                key={range}
+                type="button"
+                onClick={() => setDateRange(range)}
+                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                  dateRange === range
+                    ? 'bg-white dark:bg-gray-800 shadow-sm'
+                    : 'hover:bg-white/50 dark:hover:bg-gray-800/50'
+                }`}
+              >
+                {range === '7d' && 'Last 7 Days'}
+                {range === '30d' && 'Last 30 Days'}
+                {range === '90d' && 'Last 90 Days'}
+                {range === 'all' && 'All Time'}
+              </button>
+            ))}
+          </div>
+          <Button variant="outline" size="sm" onClick={exportCSV} disabled={!history}>
+            Export CSV
+          </Button>
+        </div>
+
+        {loading && (
+          <Card>
+            <CardContent className="py-8 text-center">
+              <div className="animate-pulse">Loading statistics...</div>
+            </CardContent>
+          </Card>
+        )}
+
+        {error && !loading && (
+          <Card>
+            <CardContent className="py-8 text-center text-red-600 dark:text-red-400">{error}</CardContent>
+          </Card>
+        )}
+
+        {!loading && !error && stats && history && (
+          <div className="space-y-6">
+            {/* Summary Cards */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="text-center">
+                    <div className="text-3xl font-bold text-primary">{stats.user.rating}</div>
+                    <div className="text-sm text-muted-foreground">Current Rating</div>
+                    {stats.stats.ratingTrend !== 'stable' && (
+                      <div
+                        className={`text-xs mt-1 ${
+                          stats.stats.ratingTrend === 'improving'
+                            ? 'text-green-600 dark:text-green-400'
+                            : 'text-red-600 dark:text-red-400'
+                        }`}
+                      >
+                        {stats.stats.ratingTrend === 'improving' ? '↑' : '↓'} {stats.stats.recentRatingChange}
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="text-center">
+                    <div className="text-3xl font-bold">{history.summary.totalGames}</div>
+                    <div className="text-sm text-muted-foreground">Games Played</div>
+                    <div className="text-xs text-muted-foreground mt-1">in selected period</div>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="text-center">
+                    <div className="text-3xl font-bold text-green-600 dark:text-green-400">{winRate}%</div>
+                    <div className="text-sm text-muted-foreground">Win Rate</div>
+                    <div className="text-xs text-muted-foreground mt-1">overall</div>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="text-center">
+                    <div
+                      className={`text-3xl font-bold ${
+                        stats.stats.currentStreak >= 0
+                          ? 'text-green-600 dark:text-green-400'
+                          : 'text-red-600 dark:text-red-400'
+                      }`}
+                    >
+                      {stats.stats.currentStreak >= 0
+                        ? `W${stats.stats.currentStreak}`
+                        : `L${Math.abs(stats.stats.currentStreak)}`}
+                    </div>
+                    <div className="text-sm text-muted-foreground">Current Streak</div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Charts Row */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {/* Win/Loss/Draw Pie Chart */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Game Outcomes</CardTitle>
+                  <CardDescription>Win/Loss/Draw distribution</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {pieData.length > 0 ? (
+                    <ResponsiveContainer width="100%" height={250}>
+                      <PieChart>
+                        <Pie
+                          data={pieData}
+                          cx="50%"
+                          cy="50%"
+                          innerRadius={60}
+                          outerRadius={100}
+                          paddingAngle={2}
+                          dataKey="value"
+                          label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(0)}%`}
+                        >
+                          {pieData.map((entry, index) => (
+                            <Cell key={`cell-${index}`} fill={entry.color} />
+                          ))}
+                        </Pie>
+                        <Tooltip />
+                        <Legend />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  ) : (
+                    <div className="h-[250px] flex items-center justify-center text-muted-foreground">
+                      No games in selected period
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* Win Rate Over Time */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Win Rate Trend</CardTitle>
+                  <CardDescription>Cumulative win percentage over time</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {history.winRateOverTime.length > 0 ? (
+                    <ResponsiveContainer width="100%" height={250}>
+                      <LineChart data={history.winRateOverTime}>
+                        <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                        <XAxis dataKey="date" tickFormatter={formatDate} className="text-xs" />
+                        <YAxis domain={[0, 100]} className="text-xs" />
+                        <Tooltip
+                          labelFormatter={(label) => formatDate(label as string)}
+                          formatter={(value) => [`${value}%`, 'Win Rate']}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey="winRate"
+                          stroke={COLORS.primary}
+                          strokeWidth={2}
+                          dot={false}
+                          activeDot={{ r: 4 }}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  ) : (
+                    <div className="h-[250px] flex items-center justify-center text-muted-foreground">
+                      No games in selected period
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Rating History Chart */}
+            {stats.ratingHistory.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Rating History</CardTitle>
+                  <CardDescription>
+                    Your ELO rating progression (Peak: {stats.stats.peakRating}, Low: {stats.stats.lowestRating})
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ResponsiveContainer width="100%" height={300}>
+                    <AreaChart
+                      data={stats.ratingHistory.slice(-50).map((entry) => ({
+                        date: new Date(entry.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+                        rating: entry.rating,
+                      }))}
+                    >
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                      <XAxis dataKey="date" className="text-xs" />
+                      <YAxis
+                        domain={['dataMin - 50', 'dataMax + 50']}
+                        className="text-xs"
+                      />
+                      <Tooltip />
+                      <Area
+                        type="monotone"
+                        dataKey="rating"
+                        stroke={COLORS.primary}
+                        fill={COLORS.primary}
+                        fillOpacity={0.2}
+                        strokeWidth={2}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Games Per Day Chart */}
+            {history.dailyStats.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Daily Activity</CardTitle>
+                  <CardDescription>Games played per day with outcomes</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ResponsiveContainer width="100%" height={250}>
+                    <BarChart data={history.dailyStats}>
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                      <XAxis dataKey="date" tickFormatter={formatDate} className="text-xs" />
+                      <YAxis className="text-xs" />
+                      <Tooltip labelFormatter={(label) => formatDate(label as string)} />
+                      <Legend />
+                      <Bar dataKey="wins" stackId="a" fill={COLORS.wins} name="Wins" />
+                      <Bar dataKey="losses" stackId="a" fill={COLORS.losses} name="Losses" />
+                      <Bar dataKey="draws" stackId="a" fill={COLORS.draws} name="Draws" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Performance Analysis */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {/* Position Stats */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Performance by Position</CardTitle>
+                  <CardDescription>Win rate as Player 1 (Red) vs Player 2 (Yellow)</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    <div>
+                      <div className="flex justify-between mb-1">
+                        <span className="text-sm font-medium">Player 1 (Red - First)</span>
+                        <span className="text-sm text-muted-foreground">{history.summary.player1WinRate}%</span>
+                      </div>
+                      <div className="w-full bg-muted rounded-full h-3">
+                        <div
+                          className="bg-red-500 h-3 rounded-full transition-all"
+                          style={{ width: `${history.summary.player1WinRate}%` }}
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <div className="flex justify-between mb-1">
+                        <span className="text-sm font-medium">Player 2 (Yellow - Second)</span>
+                        <span className="text-sm text-muted-foreground">{history.summary.player2WinRate}%</span>
+                      </div>
+                      <div className="w-full bg-muted rounded-full h-3">
+                        <div
+                          className="bg-yellow-500 h-3 rounded-full transition-all"
+                          style={{ width: `${history.summary.player2WinRate}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Game Length Analysis */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Game Length Analysis</CardTitle>
+                  <CardDescription>Average moves to win vs loss</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4 text-center">
+                      <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
+                        <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+                          {history.summary.avgMovesToWin || '-'}
+                        </div>
+                        <div className="text-sm text-muted-foreground">Avg Moves to Win</div>
+                      </div>
+                      <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-lg">
+                        <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+                          {history.summary.avgMovesToLoss || '-'}
+                        </div>
+                        <div className="text-sm text-muted-foreground">Avg Moves to Loss</div>
+                      </div>
+                    </div>
+                    <p className="text-xs text-muted-foreground text-center">
+                      {history.summary.avgMovesToWin < history.summary.avgMovesToLoss
+                        ? 'You tend to win games faster than you lose them - efficient play!'
+                        : history.summary.avgMovesToWin > history.summary.avgMovesToLoss
+                          ? 'Your losses tend to come quicker - watch for early mistakes'
+                          : 'Your win and loss game lengths are similar'}
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Opening Column Stats */}
+            {history.openingStats.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Opening Column Analysis</CardTitle>
+                  <CardDescription>Performance by your first move column</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                    {history.openingStats.slice(0, 8).map((opening) => (
+                      <div
+                        key={opening.column}
+                        className="p-4 bg-muted/50 rounded-lg text-center"
+                      >
+                        <div className="text-lg font-semibold">{COLUMN_NAMES[opening.column]}</div>
+                        <div className="text-xs text-muted-foreground mb-2">Column {opening.column + 1}</div>
+                        <div
+                          className={`text-2xl font-bold ${
+                            opening.winRate >= 50
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-red-600 dark:text-red-400'
+                          }`}
+                        >
+                          {opening.winRate}%
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {opening.games} games ({opening.wins}W/{opening.losses}L/{opening.draws}D)
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  {history.openingStats.length > 0 && (
+                    <div className="mt-4 text-center text-sm text-muted-foreground">
+                      Best opening:{' '}
+                      <span className="font-medium text-green-600 dark:text-green-400">
+                        {COLUMN_NAMES[history.openingStats.reduce((best, curr) =>
+                          curr.winRate > best.winRate && curr.games >= 3 ? curr : best
+                        ).column]}
+                      </span>
+                      {' | '}
+                      Most used:{' '}
+                      <span className="font-medium">{COLUMN_NAMES[history.openingStats[0].column]}</span>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Streak Records */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Streak Records</CardTitle>
+                <CardDescription>Your best and worst streaks</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-center">
+                  <div className="p-4 bg-muted/50 rounded-lg">
+                    <div
+                      className={`text-2xl font-bold ${
+                        stats.stats.currentStreak >= 0
+                          ? 'text-green-600 dark:text-green-400'
+                          : 'text-red-600 dark:text-red-400'
+                      }`}
+                    >
+                      {stats.stats.currentStreak >= 0
+                        ? `W${stats.stats.currentStreak}`
+                        : `L${Math.abs(stats.stats.currentStreak)}`}
+                    </div>
+                    <div className="text-sm text-muted-foreground">Current Streak</div>
+                  </div>
+                  <div className="p-4 bg-muted/50 rounded-lg">
+                    <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+                      {stats.stats.longestWinStreak}
+                    </div>
+                    <div className="text-sm text-muted-foreground">Best Win Streak</div>
+                  </div>
+                  <div className="p-4 bg-muted/50 rounded-lg">
+                    <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+                      {stats.stats.longestLossStreak}
+                    </div>
+                    <div className="text-sm text-muted-foreground">Worst Loss Streak</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Recent Games */}
+            {history.recentGames.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Recent Form</CardTitle>
+                  <CardDescription>Your last {history.recentGames.length} games</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex flex-wrap gap-2 mb-4">
+                    {history.recentGames.map((game) => (
+                      <div
+                        key={game.id}
+                        className={`w-8 h-8 rounded flex items-center justify-center text-white text-sm font-bold ${
+                          game.outcome === 'win'
+                            ? 'bg-green-500'
+                            : game.outcome === 'loss'
+                              ? 'bg-red-500'
+                              : 'bg-yellow-500'
+                        }`}
+                        title={`${game.outcome.charAt(0).toUpperCase() + game.outcome.slice(1)} vs ${game.opponentType}${game.aiDifficulty ? ` (${game.aiDifficulty})` : ''} - ${game.moveCount} moves`}
+                      >
+                        {game.outcome === 'win' ? 'W' : game.outcome === 'loss' ? 'L' : 'D'}
+                      </div>
+                    ))}
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b">
+                          <th className="text-left py-2">Result</th>
+                          <th className="text-left py-2">Opponent</th>
+                          <th className="text-left py-2">Position</th>
+                          <th className="text-left py-2">Moves</th>
+                          <th className="text-right py-2">Rating</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {history.recentGames.map((game) => (
+                          <tr key={game.id} className="border-b border-muted">
+                            <td className="py-2">
+                              <span
+                                className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                                  game.outcome === 'win'
+                                    ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                                    : game.outcome === 'loss'
+                                      ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                                      : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+                                }`}
+                              >
+                                {game.outcome.toUpperCase()}
+                              </span>
+                            </td>
+                            <td className="py-2 capitalize">
+                              {game.opponentType}
+                              {game.aiDifficulty && (
+                                <span className="text-muted-foreground text-xs ml-1">({game.aiDifficulty})</span>
+                              )}
+                            </td>
+                            <td className="py-2">{game.playerNumber === 1 ? 'Red (1st)' : 'Yellow (2nd)'}</td>
+                            <td className="py-2">{game.moveCount}</td>
+                            <td
+                              className={`py-2 text-right font-medium ${
+                                game.ratingChange > 0
+                                  ? 'text-green-600 dark:text-green-400'
+                                  : game.ratingChange < 0
+                                    ? 'text-red-600 dark:text-red-400'
+                                    : 'text-muted-foreground'
+                              }`}
+                            >
+                              {game.ratingChange > 0 ? '+' : ''}
+                              {game.ratingChange}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Empty State */}
+            {history.summary.totalGames === 0 && (
+              <Card>
+                <CardContent className="py-12 text-center">
+                  <div className="text-muted-foreground mb-4">No games found in the selected period.</div>
+                  <Link to="/play">
+                    <Button>Play a Game</Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `/api/users/me/stats/history` endpoint with date range filtering for time-series data
- Create dedicated `/stats` page with interactive Recharts visualizations:
  - Win/loss/draw pie chart
  - Win rate trend line chart
  - Rating history area chart
  - Daily activity stacked bar chart
  - Performance by position analysis
  - Opening column analysis
  - Streak records
  - Recent form table
- Support date range filters (7d, 30d, 90d, all time)
- Add CSV export functionality
- Add navigation links to dashboard and header

## Test plan

- [ ] Verify stats page loads correctly at `/stats`
- [ ] Test date range filtering (7d, 30d, 90d, all)
- [ ] Check all charts render with game data
- [ ] Verify CSV export downloads correctly
- [ ] Test empty state when no games in range
- [ ] Confirm mobile responsiveness

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)