### PR TITLE
fix: add cleanup function to bot move useEffect to prevent memory leak

### DIFF
--- a/src/pages/PlayPage.tsx
+++ b/src/pages/PlayPage.tsx
@@ -183,11 +183,14 @@ export default function PlayPage() {
     if (settings.mode !== 'ai') return
     if (gameState.currentPlayer !== aiPlayerNumber || gameState.winner !== null) return
 
+    let cancelled = false
     setIsBotThinking(true)
 
     const makeBotMove = async () => {
       // Small delay for UX - makes it feel like the bot is "thinking"
       await new Promise((resolve) => setTimeout(resolve, 500))
+
+      if (cancelled) return
 
       const botMove = await suggestMove(
         {
@@ -198,6 +201,8 @@ export default function PlayPage() {
         settings.difficulty
       )
 
+      if (cancelled) return
+
       const newState = makeMove(gameState, botMove)
       if (newState) {
         setGameState(newState)
@@ -207,6 +212,10 @@ export default function PlayPage() {
     }
 
     makeBotMove()
+
+    return () => {
+      cancelled = true
+    }
   }, [gameState, gamePhase, settings.mode, settings.difficulty, aiPlayerNumber, sounds])
 
   const handleColumnClick = useCallback(


### PR DESCRIPTION
## Summary
- Adds a `cancelled` flag and cleanup function to the AI bot move `useEffect` in `PlayPage.tsx`
- Prevents React state updates on unmounted components when user navigates away mid-game
- Checks the cancelled flag after both the 500ms delay and the `suggestMove` async call

## Test plan
- [x] TypeScript builds without errors
- [x] All 143 tests pass
- [ ] Manual test: Start AI game, navigate away during bot's turn, verify no console warnings

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)