### PR TITLE
feat: add rate limiting to API endpoints

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,13 +1,131 @@
-// Middleware for Cloudflare Pages Functions
-// Adds CORS headers and error handling
+/**
+ * Middleware for Cloudflare Pages Functions
+ * Adds CORS headers, rate limiting, and error handling
+ */
 
-export async function onRequest(context: EventContext<any, any, any>) {
-  // Add CORS headers
+import {
+  checkRateLimit,
+  getClientIP,
+  rateLimitResponse,
+  applyRateLimitHeaders,
+  type RateLimitResult,
+} from './lib/rateLimit'
+import { validateSession } from './lib/auth'
+
+interface Env {
+  DB: D1Database
+  RATE_LIMIT: KVNamespace
+}
+
+/**
+ * Determine which rate limit rule applies based on URL path and method
+ * Returns the config key and identifier to use
+ */
+async function getRateLimitRule(
+  request: Request,
+  env: Env,
+  clientIP: string
+): Promise<{ configKey: string; identifier: string } | null> {
+  const url = new URL(request.url)
+  const path = url.pathname
+  const method = request.method
+
+  // Auth endpoints - rate limit by IP
+  if (path === '/api/auth/login' && method === 'POST') {
+    return { configKey: 'login', identifier: clientIP }
+  }
+
+  if (path === '/api/auth/register' && method === 'POST') {
+    return { configKey: 'register', identifier: clientIP }
+  }
+
+  if (path === '/api/auth/forgot-password' && method === 'POST') {
+    // For forgot password, we try to extract email from body
+    // but fall back to IP if we can't
+    try {
+      const body = await request.clone().json()
+      if (body && typeof body.email === 'string') {
+        return { configKey: 'forgotPassword', identifier: body.email.toLowerCase() }
+      }
+    } catch {
+      // Couldn't parse body, use IP
+    }
+    return { configKey: 'forgotPassword', identifier: clientIP }
+  }
+
+  // Game endpoints - rate limit by user ID (requires auth) or IP for unauthenticated
+  if (path === '/api/games') {
+    if (method === 'POST') {
+      // Try to get user ID from session
+      const session = await validateSession(request, env.DB)
+      const identifier = session.valid ? session.userId : clientIP
+      return { configKey: 'createGame', identifier }
+    }
+
+    if (method === 'GET') {
+      const session = await validateSession(request, env.DB)
+      const identifier = session.valid ? session.userId : clientIP
+      return { configKey: 'getGames', identifier }
+    }
+  }
+
+  // No specific rule for this endpoint
+  return null
+}
+
+export async function onRequest(context: EventContext<Env, any, any>) {
+  const { request, env } = context
+
+  // Skip rate limiting for OPTIONS (CORS preflight)
+  if (request.method === 'OPTIONS') {
+    const response = await context.next()
+    response.headers.set('Access-Control-Allow-Origin', '*')
+    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+    return response
+  }
+
+  // Only apply rate limiting to /api routes
+  const url = new URL(request.url)
+  const isApiRoute = url.pathname.startsWith('/api')
+
+  if (!isApiRoute || !env.RATE_LIMIT) {
+    // Not an API route or KV not configured, skip rate limiting
+    const response = await context.next()
+    response.headers.set('Access-Control-Allow-Origin', '*')
+    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+    return response
+  }
+
+  const clientIP = getClientIP(request)
+  let rateLimitResult: RateLimitResult | null = null
+
+  // 1. Check global rate limit first
+  const globalResult = await checkRateLimit(env.RATE_LIMIT, 'global', clientIP)
+  if (!globalResult.allowed) {
+    return rateLimitResponse(globalResult)
+  }
+
+  // 2. Check endpoint-specific rate limit
+  const rule = await getRateLimitRule(request, env, clientIP)
+  if (rule) {
+    const specificResult = await checkRateLimit(env.RATE_LIMIT, rule.configKey, rule.identifier)
+    if (!specificResult.allowed) {
+      return rateLimitResponse(specificResult)
+    }
+    rateLimitResult = specificResult
+  }
+
+  // Proceed with the request
   const response = await context.next()
 
+  // Add CORS headers
   response.headers.set('Access-Control-Allow-Origin', '*')
   response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
   response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 
-  return response
+  // Add rate limit headers to response (use specific limit if available, else global)
+  const headerResult = rateLimitResult || globalResult
+  return applyRateLimitHeaders(response, headerResult)
 }

--- a/functions/lib/rateLimit.ts
+++ b/functions/lib/rateLimit.ts
@@ -1,0 +1,191 @@
+/**
+ * Rate limiting utilities using Cloudflare KV storage
+ *
+ * Implements a sliding window rate limiter with configurable limits
+ * for different endpoints and identifiers (IP, user ID, email).
+ */
+
+interface RateLimitConfig {
+  limit: number // Max requests allowed
+  windowMs: number // Time window in milliseconds
+  keyPrefix: string // Prefix for KV key (e.g., 'login', 'register')
+}
+
+interface RateLimitResult {
+  allowed: boolean
+  limit: number
+  remaining: number
+  resetAt: number // Unix timestamp when window resets
+  retryAfter?: number // Seconds until next allowed request (only on blocked)
+}
+
+interface RateLimitData {
+  count: number
+  windowStart: number
+}
+
+// Rate limit configurations for different endpoints
+export const RATE_LIMITS: Record<string, RateLimitConfig> = {
+  // Auth endpoints (strict)
+  login: {
+    limit: 5,
+    windowMs: 60 * 1000, // 1 minute
+    keyPrefix: 'rl:login',
+  },
+  register: {
+    limit: 3,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    keyPrefix: 'rl:register',
+  },
+  forgotPassword: {
+    limit: 3,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    keyPrefix: 'rl:forgot',
+  },
+
+  // Game endpoints (moderate)
+  createGame: {
+    limit: 60,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    keyPrefix: 'rl:create-game',
+  },
+  getGames: {
+    limit: 100,
+    windowMs: 60 * 1000, // 1 minute
+    keyPrefix: 'rl:get-games',
+  },
+
+  // Global limit
+  global: {
+    limit: 1000,
+    windowMs: 60 * 1000, // 1 minute
+    keyPrefix: 'rl:global',
+  },
+}
+
+/**
+ * Check and update rate limit for a given identifier
+ *
+ * Uses sliding window algorithm:
+ * - Stores count and window start time in KV
+ * - If within window, increments count
+ * - If window expired, resets count
+ *
+ * @param kv - KV namespace for rate limit storage
+ * @param configKey - Key from RATE_LIMITS (e.g., 'login', 'global')
+ * @param identifier - Unique identifier (IP address, user ID, or email)
+ * @returns RateLimitResult with allowed status and headers info
+ */
+export async function checkRateLimit(
+  kv: KVNamespace,
+  configKey: string,
+  identifier: string
+): Promise<RateLimitResult> {
+  const config = RATE_LIMITS[configKey]
+  if (!config) {
+    // Unknown config, allow by default
+    return { allowed: true, limit: 0, remaining: 0, resetAt: 0 }
+  }
+
+  const key = `${config.keyPrefix}:${identifier}`
+  const now = Date.now()
+
+  // Get current rate limit data
+  const stored = await kv.get<RateLimitData>(key, 'json')
+
+  let data: RateLimitData
+  if (!stored || now - stored.windowStart >= config.windowMs) {
+    // No data or window expired, start fresh
+    data = { count: 1, windowStart: now }
+  } else {
+    // Within window, increment count
+    data = { count: stored.count + 1, windowStart: stored.windowStart }
+  }
+
+  const resetAt = data.windowStart + config.windowMs
+  const remaining = Math.max(0, config.limit - data.count)
+  const allowed = data.count <= config.limit
+
+  // Calculate TTL for KV entry (window duration + small buffer)
+  const ttlSeconds = Math.ceil(config.windowMs / 1000) + 60
+
+  // Store updated data
+  await kv.put(key, JSON.stringify(data), { expirationTtl: ttlSeconds })
+
+  const result: RateLimitResult = {
+    allowed,
+    limit: config.limit,
+    remaining: allowed ? remaining : 0,
+    resetAt: Math.ceil(resetAt / 1000), // Convert to Unix timestamp
+  }
+
+  if (!allowed) {
+    result.retryAfter = Math.ceil((resetAt - now) / 1000)
+  }
+
+  return result
+}
+
+/**
+ * Create rate limit response headers
+ */
+export function rateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-RateLimit-Limit': result.limit.toString(),
+    'X-RateLimit-Remaining': result.remaining.toString(),
+    'X-RateLimit-Reset': result.resetAt.toString(),
+  }
+
+  if (result.retryAfter !== undefined) {
+    headers['Retry-After'] = result.retryAfter.toString()
+  }
+
+  return headers
+}
+
+/**
+ * Create a 429 Too Many Requests response
+ */
+export function rateLimitResponse(result: RateLimitResult): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'Too many requests',
+      retry_after: result.retryAfter,
+      limit: result.limit,
+      remaining: 0,
+    }),
+    {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        ...rateLimitHeaders(result),
+      },
+    }
+  )
+}
+
+/**
+ * Get client IP address from request
+ * Cloudflare provides the real client IP in CF-Connecting-IP header
+ */
+export function getClientIP(request: Request): string {
+  return (
+    request.headers.get('CF-Connecting-IP') ||
+    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
+    'unknown'
+  )
+}
+
+/**
+ * Apply rate limit headers to a response
+ */
+export function applyRateLimitHeaders(response: Response, result: RateLimitResult): Response {
+  const newResponse = new Response(response.body, response)
+  const headers = rateLimitHeaders(result)
+
+  for (const [key, value] of Object.entries(headers)) {
+    newResponse.headers.set(key, value)
+  }
+
+  return newResponse
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,11 @@ database_id = "e97c7189-5136-4901-b60c-d15105b91bfa"
 [ai]
 binding = "AI"
 
+# KV namespace for rate limiting
+[[kv_namespaces]]
+binding = "RATE_LIMIT"
+id = "rate-limit-kv"
+
 # Environment variables
 [vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
## Summary

- Implements sliding window rate limiting using Cloudflare KV storage
- Adds rate limit middleware to protect auth and game API endpoints
- Returns proper 429 responses with Retry-After and X-RateLimit-* headers

### Rate Limits

**Auth Endpoints (Strict)**
- `POST /api/auth/login`: 5 attempts/min per IP
- `POST /api/auth/register`: 3 registrations/hour per IP
- `POST /api/auth/forgot-password`: 3 requests/hour per email

**Game Endpoints (Moderate)**
- `POST /api/games`: 60 games/hour per user
- `GET /api/games`: 100 requests/min per user

**Global**
- 1000 requests/min per IP

Closes #18

## Test plan

- [ ] Verify rate limit headers appear on API responses
- [ ] Test login endpoint blocks after 5 rapid attempts
- [ ] Verify 429 response includes correct JSON format
- [ ] Confirm legitimate users are not impacted by limits
- [ ] Test that KV namespace is properly configured in Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)