### PR TITLE
feat: implement server-side user preferences for cross-device sync

### DIFF
--- a/functions/api/preferences.ts
+++ b/functions/api/preferences.ts
@@ -1,0 +1,184 @@
+import { validateSession, errorResponse, jsonResponse } from '../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+/**
+ * User preferences schema
+ */
+export interface UserPreferences {
+  // Sound settings
+  soundEnabled: boolean
+  soundVolume: number // 0-100
+
+  // Game settings
+  defaultGameMode: 'ai' | 'hotseat' | 'online'
+  defaultDifficulty: 'beginner' | 'intermediate' | 'expert' | 'perfect'
+  defaultPlayerColor: 1 | 2
+  defaultMatchmakingMode: 'ranked' | 'casual'
+  allowSpectators: boolean
+
+  // Theme
+  theme: 'light' | 'dark' | 'system'
+}
+
+const DEFAULT_PREFERENCES: UserPreferences = {
+  soundEnabled: true,
+  soundVolume: 50,
+  defaultGameMode: 'ai',
+  defaultDifficulty: 'intermediate',
+  defaultPlayerColor: 1,
+  defaultMatchmakingMode: 'ranked',
+  allowSpectators: true,
+  theme: 'system',
+}
+
+/**
+ * Validates and merges preferences with defaults
+ */
+function parsePreferences(preferencesJson: string | null): UserPreferences {
+  if (!preferencesJson) {
+    return { ...DEFAULT_PREFERENCES }
+  }
+
+  try {
+    const parsed = JSON.parse(preferencesJson)
+    return {
+      soundEnabled: typeof parsed.soundEnabled === 'boolean' ? parsed.soundEnabled : DEFAULT_PREFERENCES.soundEnabled,
+      soundVolume: typeof parsed.soundVolume === 'number' && parsed.soundVolume >= 0 && parsed.soundVolume <= 100
+        ? parsed.soundVolume
+        : DEFAULT_PREFERENCES.soundVolume,
+      defaultGameMode: ['ai', 'hotseat', 'online'].includes(parsed.defaultGameMode)
+        ? parsed.defaultGameMode
+        : DEFAULT_PREFERENCES.defaultGameMode,
+      defaultDifficulty: ['beginner', 'intermediate', 'expert', 'perfect'].includes(parsed.defaultDifficulty)
+        ? parsed.defaultDifficulty
+        : DEFAULT_PREFERENCES.defaultDifficulty,
+      defaultPlayerColor: parsed.defaultPlayerColor === 1 || parsed.defaultPlayerColor === 2
+        ? parsed.defaultPlayerColor
+        : DEFAULT_PREFERENCES.defaultPlayerColor,
+      defaultMatchmakingMode: ['ranked', 'casual'].includes(parsed.defaultMatchmakingMode)
+        ? parsed.defaultMatchmakingMode
+        : DEFAULT_PREFERENCES.defaultMatchmakingMode,
+      allowSpectators: typeof parsed.allowSpectators === 'boolean'
+        ? parsed.allowSpectators
+        : DEFAULT_PREFERENCES.allowSpectators,
+      theme: ['light', 'dark', 'system'].includes(parsed.theme)
+        ? parsed.theme
+        : DEFAULT_PREFERENCES.theme,
+    }
+  } catch {
+    return { ...DEFAULT_PREFERENCES }
+  }
+}
+
+/**
+ * GET /api/preferences - Fetch user preferences
+ *
+ * Returns the user's preferences merged with defaults.
+ * Requires authentication.
+ */
+export async function onRequestGet(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    // Validate session
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Get user preferences
+    const user = await DB.prepare('SELECT preferences FROM users WHERE id = ?')
+      .bind(session.userId)
+      .first<{ preferences: string | null }>()
+
+    if (!user) {
+      return errorResponse('User not found', 404)
+    }
+
+    const preferences = parsePreferences(user.preferences)
+
+    return jsonResponse({ preferences })
+  } catch (error) {
+    console.error('Get preferences error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+/**
+ * PUT /api/preferences - Update user preferences
+ *
+ * Accepts a partial preferences object and merges with existing preferences.
+ * Requires authentication.
+ */
+export async function onRequestPut(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    // Validate session
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Parse request body
+    let updates: Partial<UserPreferences>
+    try {
+      const body = await context.request.json()
+      updates = body.preferences || body
+    } catch {
+      return errorResponse('Invalid JSON body', 400)
+    }
+
+    // Get current preferences
+    const user = await DB.prepare('SELECT preferences FROM users WHERE id = ?')
+      .bind(session.userId)
+      .first<{ preferences: string | null }>()
+
+    if (!user) {
+      return errorResponse('User not found', 404)
+    }
+
+    const currentPreferences = parsePreferences(user.preferences)
+
+    // Merge updates with validation
+    const newPreferences: UserPreferences = {
+      soundEnabled: typeof updates.soundEnabled === 'boolean'
+        ? updates.soundEnabled
+        : currentPreferences.soundEnabled,
+      soundVolume: typeof updates.soundVolume === 'number' && updates.soundVolume >= 0 && updates.soundVolume <= 100
+        ? updates.soundVolume
+        : currentPreferences.soundVolume,
+      defaultGameMode: updates.defaultGameMode && ['ai', 'hotseat', 'online'].includes(updates.defaultGameMode)
+        ? updates.defaultGameMode
+        : currentPreferences.defaultGameMode,
+      defaultDifficulty: updates.defaultDifficulty && ['beginner', 'intermediate', 'expert', 'perfect'].includes(updates.defaultDifficulty)
+        ? updates.defaultDifficulty
+        : currentPreferences.defaultDifficulty,
+      defaultPlayerColor: updates.defaultPlayerColor === 1 || updates.defaultPlayerColor === 2
+        ? updates.defaultPlayerColor
+        : currentPreferences.defaultPlayerColor,
+      defaultMatchmakingMode: updates.defaultMatchmakingMode && ['ranked', 'casual'].includes(updates.defaultMatchmakingMode)
+        ? updates.defaultMatchmakingMode
+        : currentPreferences.defaultMatchmakingMode,
+      allowSpectators: typeof updates.allowSpectators === 'boolean'
+        ? updates.allowSpectators
+        : currentPreferences.allowSpectators,
+      theme: updates.theme && ['light', 'dark', 'system'].includes(updates.theme)
+        ? updates.theme
+        : currentPreferences.theme,
+    }
+
+    // Save to database
+    await DB.prepare('UPDATE users SET preferences = ?, updated_at = ? WHERE id = ?')
+      .bind(JSON.stringify(newPreferences), Date.now(), session.userId)
+      .run()
+
+    return jsonResponse({ preferences: newPreferences })
+  } catch (error) {
+    console.error('Update preferences error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}

--- a/migrations/003_add_preferences.sql
+++ b/migrations/003_add_preferences.sql
@@ -1,0 +1,16 @@
+-- Add user preferences for cross-device sync
+-- This migration adds a preferences column to store user settings as JSON
+
+-- Preferences column stores JSON with the following schema:
+-- {
+--   "soundEnabled": boolean (default: true),
+--   "soundVolume": number 0-100 (default: 50),
+--   "defaultGameMode": "ai" | "hotseat" | "online" (default: "ai"),
+--   "defaultDifficulty": "beginner" | "intermediate" | "expert" | "perfect" (default: "intermediate"),
+--   "defaultPlayerColor": 1 | 2 (default: 1),
+--   "defaultMatchmakingMode": "ranked" | "casual" (default: "ranked"),
+--   "allowSpectators": boolean (default: true),
+--   "theme": "light" | "dark" | "system" (default: "system")
+-- }
+
+ALTER TABLE users ADD COLUMN preferences TEXT DEFAULT '{}';

--- a/schema.sql
+++ b/schema.sql
@@ -15,6 +15,8 @@ CREATE TABLE IF NOT EXISTS users (
   wins INTEGER NOT NULL DEFAULT 0,
   losses INTEGER NOT NULL DEFAULT 0,
   draws INTEGER NOT NULL DEFAULT 0,
+  -- User preferences (JSON)
+  preferences TEXT DEFAULT '{}',
   created_at INTEGER NOT NULL,
   last_login INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
+import { PreferencesProvider } from './contexts/PreferencesContext'
 import LoginPage from './pages/LoginPage'
 import DashboardPage from './pages/DashboardPage'
 import PlayPage from './pages/PlayPage'
@@ -20,8 +21,9 @@ function App() {
   return (
     <ThemeProvider>
       <AuthProvider>
-        <BrowserRouter>
-          <Routes>
+        <PreferencesProvider>
+          <BrowserRouter>
+            <Routes>
             {/* Public routes */}
             <Route path="/" element={<PlayPage />} />
             <Route path="/play" element={<PlayPage />} />
@@ -77,8 +79,9 @@ function App() {
                 </ProtectedRoute>
               }
             />
-          </Routes>
-        </BrowserRouter>
+            </Routes>
+          </BrowserRouter>
+        </PreferencesProvider>
       </AuthProvider>
     </ThemeProvider>
   )

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -1,0 +1,58 @@
+/**
+ * Preferences Context
+ *
+ * Provides centralized user preferences that sync with the server for
+ * authenticated users and fall back to localStorage for guests.
+ */
+
+import type React from 'react'
+import { createContext, useContext } from 'react'
+import { usePreferences, type UserPreferences, DEFAULT_PREFERENCES } from '../hooks/usePreferences'
+
+interface PreferencesContextType {
+  preferences: UserPreferences
+  updatePreferences: (updates: Partial<UserPreferences>) => void
+  reload: () => Promise<void>
+  isLoading: boolean
+  isSyncing: boolean
+  error: string | null
+}
+
+const PreferencesContext = createContext<PreferencesContextType | undefined>(undefined)
+
+export function PreferencesProvider({ children }: { children: React.ReactNode }) {
+  const {
+    preferences,
+    updatePreferences,
+    reload,
+    isLoading,
+    isSyncing,
+    error,
+  } = usePreferences()
+
+  return (
+    <PreferencesContext.Provider
+      value={{
+        preferences,
+        updatePreferences,
+        reload,
+        isLoading,
+        isSyncing,
+        error,
+      }}
+    >
+      {children}
+    </PreferencesContext.Provider>
+  )
+}
+
+export function usePreferencesContext() {
+  const context = useContext(PreferencesContext)
+  if (context === undefined) {
+    throw new Error('usePreferencesContext must be used within a PreferencesProvider')
+  }
+  return context
+}
+
+export { DEFAULT_PREFERENCES }
+export type { UserPreferences }

--- a/src/hooks/usePreferences.ts
+++ b/src/hooks/usePreferences.ts
@@ -1,0 +1,261 @@
+/**
+ * Custom React hook for managing user preferences with server sync
+ *
+ * Provides centralized preference management that:
+ * - Loads from server for authenticated users
+ * - Falls back to localStorage for guests
+ * - Syncs localStorage → server on login
+ * - Debounces saves to avoid excessive API calls
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { useAuthenticatedApi } from './useAuthenticatedApi'
+
+export interface UserPreferences {
+  // Sound settings
+  soundEnabled: boolean
+  soundVolume: number // 0-100
+
+  // Game settings
+  defaultGameMode: 'ai' | 'hotseat' | 'online'
+  defaultDifficulty: 'beginner' | 'intermediate' | 'expert' | 'perfect'
+  defaultPlayerColor: 1 | 2
+  defaultMatchmakingMode: 'ranked' | 'casual'
+  allowSpectators: boolean
+
+  // Theme
+  theme: 'light' | 'dark' | 'system'
+}
+
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  soundEnabled: true,
+  soundVolume: 50,
+  defaultGameMode: 'ai',
+  defaultDifficulty: 'intermediate',
+  defaultPlayerColor: 1,
+  defaultMatchmakingMode: 'ranked',
+  allowSpectators: true,
+  theme: 'system',
+}
+
+const STORAGE_KEY = 'makefour-preferences'
+const DEBOUNCE_MS = 1000
+
+/**
+ * Load preferences from localStorage
+ */
+function loadLocalPreferences(): UserPreferences {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      const parsed = JSON.parse(saved)
+      return mergeWithDefaults(parsed)
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return { ...DEFAULT_PREFERENCES }
+}
+
+/**
+ * Save preferences to localStorage
+ */
+function saveLocalPreferences(preferences: UserPreferences) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences))
+}
+
+/**
+ * Merge partial preferences with defaults
+ */
+function mergeWithDefaults(partial: Partial<UserPreferences>): UserPreferences {
+  return {
+    soundEnabled: typeof partial.soundEnabled === 'boolean' ? partial.soundEnabled : DEFAULT_PREFERENCES.soundEnabled,
+    soundVolume: typeof partial.soundVolume === 'number' && partial.soundVolume >= 0 && partial.soundVolume <= 100
+      ? partial.soundVolume
+      : DEFAULT_PREFERENCES.soundVolume,
+    defaultGameMode: partial.defaultGameMode && ['ai', 'hotseat', 'online'].includes(partial.defaultGameMode)
+      ? partial.defaultGameMode
+      : DEFAULT_PREFERENCES.defaultGameMode,
+    defaultDifficulty: partial.defaultDifficulty && ['beginner', 'intermediate', 'expert', 'perfect'].includes(partial.defaultDifficulty)
+      ? partial.defaultDifficulty
+      : DEFAULT_PREFERENCES.defaultDifficulty,
+    defaultPlayerColor: partial.defaultPlayerColor === 1 || partial.defaultPlayerColor === 2
+      ? partial.defaultPlayerColor
+      : DEFAULT_PREFERENCES.defaultPlayerColor,
+    defaultMatchmakingMode: partial.defaultMatchmakingMode && ['ranked', 'casual'].includes(partial.defaultMatchmakingMode)
+      ? partial.defaultMatchmakingMode
+      : DEFAULT_PREFERENCES.defaultMatchmakingMode,
+    allowSpectators: typeof partial.allowSpectators === 'boolean'
+      ? partial.allowSpectators
+      : DEFAULT_PREFERENCES.allowSpectators,
+    theme: partial.theme && ['light', 'dark', 'system'].includes(partial.theme)
+      ? partial.theme
+      : DEFAULT_PREFERENCES.theme,
+  }
+}
+
+export function usePreferences() {
+  const { isAuthenticated } = useAuth()
+  const { apiCall, getSessionToken } = useAuthenticatedApi()
+  const [preferences, setPreferences] = useState<UserPreferences>(loadLocalPreferences)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSyncing, setIsSyncing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Refs for debouncing
+  const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const pendingUpdateRef = useRef<Partial<UserPreferences> | null>(null)
+  const isInitialLoadRef = useRef(true)
+  const previousAuthStateRef = useRef(isAuthenticated)
+
+  /**
+   * Save preferences to server (debounced)
+   */
+  const saveToServer = useCallback(async (prefs: UserPreferences) => {
+    if (!getSessionToken()) return
+
+    try {
+      setIsSyncing(true)
+      await apiCall('/api/preferences', {
+        method: 'PUT',
+        body: JSON.stringify({ preferences: prefs }),
+      })
+      setError(null)
+    } catch (err) {
+      console.error('Failed to save preferences to server:', err)
+      setError(err instanceof Error ? err.message : 'Failed to save preferences')
+    } finally {
+      setIsSyncing(false)
+    }
+  }, [apiCall, getSessionToken])
+
+  /**
+   * Load preferences from server
+   */
+  const loadFromServer = useCallback(async () => {
+    if (!getSessionToken()) return null
+
+    try {
+      setIsLoading(true)
+      const response = await apiCall<{ preferences: UserPreferences }>('/api/preferences')
+      setError(null)
+      return response.preferences
+    } catch (err) {
+      console.error('Failed to load preferences from server:', err)
+      setError(err instanceof Error ? err.message : 'Failed to load preferences')
+      return null
+    } finally {
+      setIsLoading(false)
+    }
+  }, [apiCall, getSessionToken])
+
+  /**
+   * Sync localStorage to server on login
+   * Strategy: Use localStorage values if they differ from defaults (user has customized)
+   */
+  const syncOnLogin = useCallback(async () => {
+    const localPrefs = loadLocalPreferences()
+    const serverPrefs = await loadFromServer()
+
+    if (serverPrefs) {
+      // Check if localStorage has customized preferences
+      const localIsCustomized = JSON.stringify(localPrefs) !== JSON.stringify(DEFAULT_PREFERENCES)
+      const serverIsDefault = JSON.stringify(serverPrefs) === JSON.stringify(DEFAULT_PREFERENCES)
+
+      if (localIsCustomized && serverIsDefault) {
+        // User has local customizations, server is default -> push local to server
+        setPreferences(localPrefs)
+        await saveToServer(localPrefs)
+      } else {
+        // Use server preferences (server wins)
+        setPreferences(serverPrefs)
+        saveLocalPreferences(serverPrefs)
+      }
+    }
+  }, [loadFromServer, saveToServer])
+
+  // Load preferences on mount and handle auth state changes
+  useEffect(() => {
+    const wasAuthenticated = previousAuthStateRef.current
+    previousAuthStateRef.current = isAuthenticated
+
+    if (isAuthenticated) {
+      if (isInitialLoadRef.current || !wasAuthenticated) {
+        // Initial load or just logged in
+        isInitialLoadRef.current = false
+        syncOnLogin()
+      }
+    } else {
+      // Not authenticated, use localStorage
+      setPreferences(loadLocalPreferences())
+    }
+  }, [isAuthenticated, syncOnLogin])
+
+  /**
+   * Update preferences (debounced for server sync)
+   */
+  const updatePreferences = useCallback((updates: Partial<UserPreferences>) => {
+    setPreferences((current) => {
+      const newPrefs = mergeWithDefaults({ ...current, ...updates })
+
+      // Always save to localStorage immediately
+      saveLocalPreferences(newPrefs)
+
+      // Debounce server sync for authenticated users
+      if (getSessionToken()) {
+        if (debounceTimeoutRef.current) {
+          clearTimeout(debounceTimeoutRef.current)
+        }
+
+        // Accumulate pending updates
+        pendingUpdateRef.current = {
+          ...pendingUpdateRef.current,
+          ...updates,
+        }
+
+        debounceTimeoutRef.current = setTimeout(() => {
+          if (pendingUpdateRef.current) {
+            saveToServer(newPrefs)
+            pendingUpdateRef.current = null
+          }
+        }, DEBOUNCE_MS)
+      }
+
+      return newPrefs
+    })
+  }, [getSessionToken, saveToServer])
+
+  /**
+   * Reload preferences from server
+   */
+  const reload = useCallback(async () => {
+    if (isAuthenticated) {
+      const serverPrefs = await loadFromServer()
+      if (serverPrefs) {
+        setPreferences(serverPrefs)
+        saveLocalPreferences(serverPrefs)
+      }
+    } else {
+      setPreferences(loadLocalPreferences())
+    }
+  }, [isAuthenticated, loadFromServer])
+
+  // Cleanup debounce timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  return {
+    preferences,
+    updatePreferences,
+    reload,
+    isLoading,
+    isSyncing,
+    error,
+  }
+}


### PR DESCRIPTION
## Summary

- Add centralized preference management system that syncs user settings to the server for authenticated users
- Preferences persist across devices and browsers for logged-in users
- Maintains localStorage fallback for guest users
- Implements debounced API calls to prevent spam when adjusting settings like volume slider

## Changes

### Database
- Add `preferences` TEXT column to users table (migration 003)
- Stores JSON with sound settings, game defaults, and theme preference

### API
- `GET /api/preferences` - Fetch user preferences (authenticated)
- `PUT /api/preferences` - Update user preferences with partial updates (authenticated)

### Client
- `usePreferences` hook with server sync and debouncing
- `PreferencesContext` for app-wide preference access
- Updated `useSounds` to use centralized preferences
- Updated `PlayPage` to sync game settings with preferences

### Preferences Schema
```typescript
interface UserPreferences {
  soundEnabled: boolean
  soundVolume: number // 0-100
  defaultGameMode: 'ai' | 'hotseat' | 'online'
  defaultDifficulty: 'beginner' | 'intermediate' | 'expert' | 'perfect'
  defaultPlayerColor: 1 | 2
  defaultMatchmakingMode: 'ranked' | 'casual'
  allowSpectators: boolean
  theme: 'light' | 'dark' | 'system'
}
```

### Sync Strategy
- On login: merge localStorage with server (server wins on conflict, unless server is default and local is customized)
- On change: debounce API calls (1 second) to prevent spam
- On logout: keep localStorage copy for guest experience

## Test Plan

- [ ] Build passes (`pnpm build`)
- [ ] All tests pass (`pnpm test`)
- [ ] Preferences persist when logging in from new device
- [ ] Changing preferences updates server (check network tab)
- [ ] Guest users still have localStorage persistence
- [ ] Volume slider changes don't spam API calls (debouncing works)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)