### PR TITLE
feat: implement bot users on leaderboard with dynamic ELO ratings

### DIFF
--- a/functions/api/bot/personas/[id].ts
+++ b/functions/api/bot/personas/[id].ts
@@ -1,7 +1,7 @@
 /**
  * Bot Persona by ID API endpoint
  *
- * GET /api/bot/personas/:id - Get a specific bot persona
+ * GET /api/bot/personas/:id - Get a specific bot persona with full profile
  */
 
 import { jsonResponse, errorResponse } from '../../../lib/auth'
@@ -27,10 +27,28 @@ interface BotPersonaRow {
   losses: number
   draws: number
   is_active: number
+  created_at: number
+}
+
+interface BotUserRow {
+  rating: number
+  games_played: number
+  wins: number
+  losses: number
+  draws: number
+}
+
+interface RecentGameRow {
+  id: string
+  outcome: string
+  move_count: number
+  rating_change: number
+  opponent_type: string
+  created_at: number
 }
 
 /**
- * GET /api/bot/personas/:id - Get a specific bot persona
+ * GET /api/bot/personas/:id - Get a specific bot persona with full profile
  */
 export async function onRequestGet(context: EventContext<Env, any, { id: string }>) {
   const { DB } = context.env
@@ -40,7 +58,7 @@ export async function onRequestGet(context: EventContext<Env, any, { id: string 
     const persona = await DB.prepare(`
       SELECT id, name, description, avatar_url, ai_engine, ai_config,
              chat_personality, play_style, base_elo, current_elo,
-             games_played, wins, losses, draws, is_active
+             games_played, wins, losses, draws, is_active, created_at
       FROM bot_personas
       WHERE id = ? AND is_active = 1
     `)
@@ -51,24 +69,79 @@ export async function onRequestGet(context: EventContext<Env, any, { id: string 
       return errorResponse('Bot persona not found', 404)
     }
 
+    // Get bot user stats (from users table - may have different values)
+    const botUserId = `bot_${id}`
+    const botUser = await DB.prepare(`
+      SELECT rating, games_played, wins, losses, draws
+      FROM users
+      WHERE id = ? AND is_bot = 1
+    `)
+      .bind(botUserId)
+      .first<BotUserRow>()
+
+    // Get recent games for this bot
+    const recentGames = await DB.prepare(`
+      SELECT id, outcome, move_count, rating_change, opponent_type, created_at
+      FROM games
+      WHERE user_id = ?
+      ORDER BY created_at DESC
+      LIMIT 10
+    `)
+      .bind(botUserId)
+      .all<RecentGameRow>()
+
+    // Get rating history
+    const ratingHistory = await DB.prepare(`
+      SELECT rating_after as rating, created_at
+      FROM rating_history
+      WHERE user_id = ?
+      ORDER BY created_at DESC
+      LIMIT 20
+    `)
+      .bind(botUserId)
+      .all<{ rating: number; created_at: number }>()
+
+    // Use bot user stats if available, otherwise fall back to persona stats
+    const stats = botUser || {
+      rating: persona.current_elo,
+      games_played: persona.games_played,
+      wins: persona.wins,
+      losses: persona.losses,
+      draws: persona.draws,
+    }
+
     return jsonResponse({
       id: persona.id,
       name: persona.name,
       description: persona.description,
       avatarUrl: persona.avatar_url,
       playStyle: persona.play_style,
-      rating: persona.current_elo,
-      gamesPlayed: persona.games_played,
-      wins: persona.wins,
-      losses: persona.losses,
-      draws: persona.draws,
+      baseElo: persona.base_elo,
+      createdAt: persona.created_at,
+      // Stats from bot user (or persona as fallback)
+      rating: stats.rating,
+      gamesPlayed: stats.games_played,
+      wins: stats.wins,
+      losses: stats.losses,
+      draws: stats.draws,
       winRate:
-        persona.games_played > 0
-          ? Math.round((persona.wins / persona.games_played) * 100)
+        stats.games_played > 0
+          ? Math.round((stats.wins / stats.games_played) * 100)
           : 0,
       // Include AI config for game creation
       aiConfig: JSON.parse(persona.ai_config),
       chatPersonality: JSON.parse(persona.chat_personality),
+      // Recent games
+      recentGames: recentGames.results.map(game => ({
+        id: game.id,
+        outcome: game.outcome,
+        moveCount: game.move_count,
+        ratingChange: game.rating_change,
+        opponentType: game.opponent_type,
+        createdAt: game.created_at,
+      })),
+      // Rating history (reversed for chronological order)
+      ratingHistory: ratingHistory.results.reverse(),
     })
   } catch (error) {
     console.error('GET /api/bot/personas/:id error:', error)

--- a/migrations/005_add_bot_users.sql
+++ b/migrations/005_add_bot_users.sql
@@ -1,0 +1,40 @@
+-- Add bot user infrastructure to users table
+-- This migration adds is_bot and bot_persona_id columns and creates user accounts for each bot persona
+
+-- Add is_bot column to users table
+ALTER TABLE users ADD COLUMN is_bot INTEGER NOT NULL DEFAULT 0;
+
+-- Add bot_persona_id column to users table
+ALTER TABLE users ADD COLUMN bot_persona_id TEXT REFERENCES bot_personas(id);
+
+-- Create indexes for bot-related queries
+CREATE INDEX IF NOT EXISTS idx_users_is_bot ON users(is_bot);
+CREATE INDEX IF NOT EXISTS idx_users_bot_persona ON users(bot_persona_id);
+
+-- Create bot user accounts for each existing persona
+-- Bot user ID format: bot_<persona_id>
+-- Email format: <persona_id>@bot.makefour.game
+INSERT INTO users (id, email, email_verified, rating, games_played, wins, losses, draws, is_bot, bot_persona_id, created_at, last_login, updated_at)
+SELECT
+  'bot_' || id,
+  id || '@bot.makefour.game',
+  1,  -- email_verified (bots are always "verified")
+  current_elo,
+  games_played,
+  wins,
+  losses,
+  draws,
+  1,  -- is_bot
+  id,
+  created_at,
+  created_at,
+  updated_at
+FROM bot_personas
+WHERE is_active = 1
+ON CONFLICT (id) DO UPDATE SET
+  rating = excluded.rating,
+  games_played = excluded.games_played,
+  wins = excluded.wins,
+  losses = excluded.losses,
+  draws = excluded.draws,
+  updated_at = excluded.updated_at;

--- a/schema.sql
+++ b/schema.sql
@@ -17,12 +17,17 @@ CREATE TABLE IF NOT EXISTS users (
   draws INTEGER NOT NULL DEFAULT 0,
   -- User preferences (JSON)
   preferences TEXT DEFAULT '{}',
+  -- Bot user fields
+  is_bot INTEGER NOT NULL DEFAULT 0,
+  bot_persona_id TEXT,
   created_at INTEGER NOT NULL,
   last_login INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
   CHECK (email_verified IN (0, 1)),
   CHECK (oauth_provider IS NULL OR oauth_provider IN ('google')),
-  CHECK (password_hash IS NOT NULL OR oauth_provider IS NOT NULL)
+  CHECK (is_bot IN (0, 1)),
+  CHECK (password_hash IS NOT NULL OR oauth_provider IS NOT NULL OR is_bot = 1),
+  FOREIGN KEY (bot_persona_id) REFERENCES bot_personas(id)
 );
 
 -- Session tokens for persistent login
@@ -85,6 +90,8 @@ CREATE TABLE IF NOT EXISTS games (
 -- Indexes for users
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_oauth ON users(oauth_provider, oauth_id);
+CREATE INDEX IF NOT EXISTS idx_users_is_bot ON users(is_bot);
+CREATE INDEX IF NOT EXISTS idx_users_bot_persona ON users(bot_persona_id);
 
 -- Indexes for session tokens
 CREATE INDEX IF NOT EXISTS idx_session_tokens_user ON session_tokens(user_id);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import SpectatorPage from './pages/SpectatorPage'
 import ProfilePage from './pages/ProfilePage'
 import StatsPage from './pages/StatsPage'
 import VerifyEmailPage from './pages/VerifyEmailPage'
+import BotProfilePage from './pages/BotProfilePage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
@@ -35,6 +36,7 @@ function App() {
             <Route path="/reset-password" element={<ResetPasswordPage />} />
             <Route path="/spectate" element={<SpectatorPage />} />
             <Route path="/verify-email" element={<VerifyEmailPage />} />
+            <Route path="/bot/:id" element={<BotProfilePage />} />
 
             {/* Protected routes - require authentication */}
             <Route

--- a/src/pages/BotProfilePage.tsx
+++ b/src/pages/BotProfilePage.tsx
@@ -1,0 +1,312 @@
+import { useState, useEffect } from 'react'
+import { Link, useParams, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import { Button } from '../components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import ThemeToggle from '../components/ThemeToggle'
+
+interface RecentGame {
+  id: string
+  outcome: 'win' | 'loss' | 'draw'
+  moveCount: number
+  ratingChange: number
+  opponentType: string
+  createdAt: number
+}
+
+interface BotProfile {
+  id: string
+  name: string
+  description: string
+  avatarUrl: string | null
+  playStyle: string
+  baseElo: number
+  createdAt: number
+  rating: number
+  gamesPlayed: number
+  wins: number
+  losses: number
+  draws: number
+  winRate: number
+  recentGames: RecentGame[]
+  ratingHistory: Array<{ rating: number; createdAt: number }>
+}
+
+export default function BotProfilePage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { isAuthenticated } = useAuth()
+  const [profile, setProfile] = useState<BotProfile | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchBotProfile() {
+      if (!id) return
+
+      try {
+        setLoading(true)
+        const response = await fetch(`/api/bot/personas/${id}`)
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error('Bot not found')
+          }
+          throw new Error('Failed to fetch bot profile')
+        }
+        const data = await response.json()
+        setProfile(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchBotProfile()
+  }, [id])
+
+  const handleChallenge = () => {
+    // Navigate to play page with bot pre-selected
+    navigate(`/play?bot=${id}`)
+  }
+
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+
+  const getPlayStyleColor = (style: string) => {
+    switch (style) {
+      case 'aggressive':
+        return 'text-red-600 dark:text-red-400'
+      case 'defensive':
+        return 'text-blue-600 dark:text-blue-400'
+      case 'tricky':
+        return 'text-purple-600 dark:text-purple-400'
+      case 'adaptive':
+        return 'text-green-600 dark:text-green-400'
+      default:
+        return 'text-gray-600 dark:text-gray-400'
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <header className="border-b bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm">
+        <div className="container mx-auto px-4 py-4 flex justify-between items-center">
+          <div className="flex items-center gap-4">
+            <Link to="/leaderboard">
+              <Button variant="ghost" size="sm">
+                &larr; Back to Leaderboard
+              </Button>
+            </Link>
+            <div>
+              <h1 className="text-2xl font-bold">Bot Profile</h1>
+              <p className="text-xs text-muted-foreground">AI Opponent</p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <ThemeToggle />
+            {isAuthenticated && (
+              <Link to="/dashboard">
+                <Button variant="outline" size="sm">Dashboard</Button>
+              </Link>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-8">
+        {loading && (
+          <Card>
+            <CardContent className="py-8 text-center">
+              <div className="animate-pulse">Loading bot profile...</div>
+            </CardContent>
+          </Card>
+        )}
+
+        {error && !loading && (
+          <Card>
+            <CardContent className="py-8 text-center text-red-600 dark:text-red-400">
+              {error}
+            </CardContent>
+          </Card>
+        )}
+
+        {!loading && !error && profile && (
+          <div className="space-y-6">
+            {/* Bot Info Card */}
+            <Card>
+              <CardHeader>
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-4">
+                    <div className="w-16 h-16 rounded-full bg-purple-100 dark:bg-purple-900 flex items-center justify-center">
+                      <svg className="w-8 h-8 text-purple-700 dark:text-purple-300" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <path d="M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1v1a2 2 0 01-2 2H5a2 2 0 01-2-2v-1H2a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2zm-3 13a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm6 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
+                      </svg>
+                    </div>
+                    <div>
+                      <CardTitle className="text-2xl">{profile.name}</CardTitle>
+                      <CardDescription className="mt-1">{profile.description}</CardDescription>
+                      <div className="flex items-center gap-3 mt-2">
+                        <span className={`text-sm font-medium capitalize ${getPlayStyleColor(profile.playStyle)}`}>
+                          {profile.playStyle} style
+                        </span>
+                        <span className="text-sm text-muted-foreground">
+                          Base ELO: {profile.baseElo}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  {isAuthenticated && (
+                    <Button onClick={handleChallenge} className="bg-purple-600 hover:bg-purple-700">
+                      Challenge
+                    </Button>
+                  )}
+                </div>
+              </CardHeader>
+            </Card>
+
+            {/* Stats Card */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Performance</CardTitle>
+                <CardDescription>Current rating and game statistics</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-6 items-center">
+                  <div className="text-center">
+                    <div className="text-4xl font-bold text-purple-600 dark:text-purple-400">{profile.rating}</div>
+                    <div className="text-sm text-muted-foreground">Rating</div>
+                  </div>
+                  <div className="h-16 w-px bg-border hidden sm:block" />
+                  <div className="flex gap-6 text-center">
+                    <div>
+                      <div className="text-2xl font-semibold">{profile.gamesPlayed}</div>
+                      <div className="text-sm text-muted-foreground">Games</div>
+                    </div>
+                    <div>
+                      <div className="text-2xl font-semibold text-green-600 dark:text-green-400">{profile.wins}</div>
+                      <div className="text-sm text-muted-foreground">Wins</div>
+                    </div>
+                    <div>
+                      <div className="text-2xl font-semibold text-red-600 dark:text-red-400">{profile.losses}</div>
+                      <div className="text-sm text-muted-foreground">Losses</div>
+                    </div>
+                    <div>
+                      <div className="text-2xl font-semibold text-yellow-600 dark:text-yellow-400">{profile.draws}</div>
+                      <div className="text-sm text-muted-foreground">Draws</div>
+                    </div>
+                    <div>
+                      <div className="text-2xl font-semibold">{profile.winRate}%</div>
+                      <div className="text-sm text-muted-foreground">Win Rate</div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Rating History Chart */}
+            {profile.ratingHistory.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Rating History</CardTitle>
+                  <CardDescription>Last {profile.ratingHistory.length} games</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="h-32 flex items-end gap-1">
+                    {profile.ratingHistory.map((entry, index) => {
+                      const min = Math.min(...profile.ratingHistory.map(e => e.rating))
+                      const max = Math.max(...profile.ratingHistory.map(e => e.rating))
+                      const range = max - min || 1
+                      const height = ((entry.rating - min) / range) * 100
+                      return (
+                        <div
+                          key={index}
+                          className="flex-1 bg-purple-400/60 hover:bg-purple-500 rounded-t transition-colors"
+                          style={{ height: `${Math.max(height, 5)}%` }}
+                          title={`${entry.rating} - ${formatDate(entry.createdAt)}`}
+                        />
+                      )
+                    })}
+                  </div>
+                  <div className="flex justify-between mt-2 text-xs text-muted-foreground">
+                    <span>Oldest</span>
+                    <span>Most Recent</span>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Recent Games */}
+            {profile.recentGames.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Recent Games</CardTitle>
+                  <CardDescription>Last {profile.recentGames.length} games played</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-2">
+                    {profile.recentGames.map((game) => (
+                      <div
+                        key={game.id}
+                        className="flex items-center justify-between p-3 bg-muted/50 rounded-lg"
+                      >
+                        <div className="flex items-center gap-3">
+                          <span
+                            className={`inline-flex items-center justify-center w-16 px-2 py-1 rounded text-xs font-medium ${
+                              game.outcome === 'win'
+                                ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                                : game.outcome === 'loss'
+                                ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                                : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                            }`}
+                          >
+                            {game.outcome.toUpperCase()}
+                          </span>
+                          <span className="text-sm text-muted-foreground">
+                            vs {game.opponentType}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-4">
+                          <span className="text-sm text-muted-foreground">
+                            {game.moveCount} moves
+                          </span>
+                          <span
+                            className={`text-sm font-medium ${
+                              game.ratingChange > 0
+                                ? 'text-green-600 dark:text-green-400'
+                                : game.ratingChange < 0
+                                ? 'text-red-600 dark:text-red-400'
+                                : 'text-muted-foreground'
+                            }`}
+                          >
+                            {game.ratingChange > 0 ? '+' : ''}{game.ratingChange}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {formatDate(game.createdAt)}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {profile.gamesPlayed === 0 && (
+              <Card>
+                <CardContent className="py-8 text-center text-muted-foreground">
+                  This bot hasn't played any games yet. Be the first to challenge them!
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add bot user accounts (is_bot=1) linked to bot personas that appear on the leaderboard
- Bot ratings update dynamically based on game outcomes against humans (and other bots)
- Leaderboard shows bots with visual distinction (purple robot icon) and a filter toggle
- New bot profile page (/bot/:id) shows stats, recent games, and rating history

## Changes
- **Database**: Added `is_bot` and `bot_persona_id` columns to users table
- **Migration 005**: Creates bot user accounts for each active persona
- **Bot Game API**: Uses bot user IDs (format: `bot_<persona_id>`) and updates both player ratings
- **Leaderboard API**: Includes bots with `isBot`, `botPersonaId`, and `botDescription` fields
- **LeaderboardPage**: Bot display with purple styling and "Show bots" toggle filter
- **BotProfilePage**: New page showing bot profile with stats and game history

## Test plan
- [ ] Run `pnpm test` - all 308 tests pass
- [ ] Run migration 005 on local database
- [ ] Verify bots appear on leaderboard with correct styling
- [ ] Test "Show bots" toggle filters correctly
- [ ] Verify clicking bot name navigates to /bot/:id profile
- [ ] Play a game against a bot and verify both ratings update
- [ ] Check bot profile page shows correct stats and recent games

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)