### PR TITLE
feat: implement bot avatars with emoji-based visual identity

### DIFF
--- a/functions/api/leaderboard.ts
+++ b/functions/api/leaderboard.ts
@@ -27,6 +27,7 @@ interface LeaderboardRow {
 interface BotPersonaInfo {
   name: string
   description: string
+  avatar_url: string | null
 }
 
 /**
@@ -74,13 +75,17 @@ export async function onRequestGet(context: EventContext<Env, any, any>) {
     if (botPersonaIds.length > 0) {
       const placeholders = botPersonaIds.map(() => '?').join(',')
       const personas = await DB.prepare(`
-        SELECT id, name, description FROM bot_personas WHERE id IN (${placeholders})
+        SELECT id, name, description, avatar_url FROM bot_personas WHERE id IN (${placeholders})
       `)
         .bind(...botPersonaIds)
-        .all<{ id: string; name: string; description: string }>()
+        .all<{ id: string; name: string; description: string; avatar_url: string | null }>()
 
       for (const persona of personas.results) {
-        botPersonaMap.set(persona.id, { name: persona.name, description: persona.description })
+        botPersonaMap.set(persona.id, {
+          name: persona.name,
+          description: persona.description,
+          avatar_url: persona.avatar_url,
+        })
       }
     }
 
@@ -115,6 +120,7 @@ export async function onRequestGet(context: EventContext<Env, any, any>) {
         isBot,
         botPersonaId: isBot ? player.bot_persona_id : null,
         botDescription: isBot && personaInfo ? personaInfo.description : null,
+        botAvatarUrl: isBot && personaInfo ? personaInfo.avatar_url : null,
       }
     })
 

--- a/functions/lib/botPersonas.ts
+++ b/functions/lib/botPersonas.ts
@@ -78,7 +78,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'rookie',
     name: 'Rookie',
     description: 'A friendly beginner still learning the ropes. Makes lots of mistakes but never gives up!',
-    avatar_url: null,
+    avatar_url: '🌱',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 2,
@@ -142,7 +142,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'rusty',
     name: 'Rusty',
     description: 'A friendly old-timer getting back into the game. Encouraging and self-deprecating.',
-    avatar_url: null,
+    avatar_url: '🔧',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 3,
@@ -206,7 +206,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'blitz',
     name: 'Blitz',
     description: 'A competitive, energetic bot who loves friendly trash talk and fast-paced games.',
-    avatar_url: null,
+    avatar_url: '⚡',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 4,
@@ -270,7 +270,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'nova',
     name: 'Nova',
     description: 'A promising player with flashes of brilliance. Confident but gracious.',
-    avatar_url: null,
+    avatar_url: '⭐',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 4,
@@ -334,7 +334,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'neuron',
     name: 'Neuron',
     description: 'A curious, analytical bot who processes moves methodically and sometimes gets confused.',
-    avatar_url: null,
+    avatar_url: '🧠',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 5,
@@ -398,7 +398,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'scholar',
     name: 'Scholar',
     description: 'A methodical player who has studied every opening. Analytical and precise.',
-    avatar_url: null,
+    avatar_url: '📚',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 6,
@@ -462,7 +462,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'viper',
     name: 'Viper',
     description: 'A cunning strategist who sets traps and thrives on opponent mistakes.',
-    avatar_url: null,
+    avatar_url: '🐍',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 5,
@@ -526,7 +526,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'titan',
     name: 'Titan',
     description: 'A powerful player who dominates the center and crushes opposition.',
-    avatar_url: null,
+    avatar_url: '🏔️',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 7,
@@ -590,7 +590,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'sentinel',
     name: 'Sentinel',
     description: 'A stoic defender who speaks few words but plays with unwavering precision.',
-    avatar_url: null,
+    avatar_url: '🛡️',
     ai_engine: 'minimax',
     ai_config: {
       searchDepth: 10,
@@ -654,7 +654,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'oracle',
     name: 'Oracle',
     description: 'A mysterious seer who speaks in riddles and plays with perfect foresight.',
-    avatar_url: null,
+    avatar_url: '🔮',
     ai_engine: 'deep-minimax',
     ai_config: {
       searchDepth: 42,
@@ -719,7 +719,7 @@ export const DEFAULT_BOT_PERSONAS: BotPersona[] = [
     id: 'neuron',
     name: 'Neuron',
     description: 'Plays by intuition using pattern recognition. Sometimes brilliant, sometimes baffling.',
-    avatar_url: null,
+    avatar_url: '🧠',
     ai_engine: 'neural',
     ai_config: {
       searchDepth: 3, // hybridDepth for neural engine

--- a/src/components/BotAvatar.tsx
+++ b/src/components/BotAvatar.tsx
@@ -1,0 +1,91 @@
+/**
+ * Bot Avatar Component
+ *
+ * Displays a bot's avatar (emoji or fallback icon).
+ * Supports multiple sizes and consistent styling across the app.
+ */
+
+import { cn } from '../lib/utils'
+
+interface BotAvatarProps {
+  avatarUrl: string | null
+  name: string
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  className?: string
+}
+
+const SIZE_CLASSES = {
+  xs: 'w-5 h-5 text-sm',
+  sm: 'w-8 h-8 text-lg',
+  md: 'w-10 h-10 text-xl',
+  lg: 'w-12 h-12 text-2xl',
+  xl: 'w-16 h-16 text-3xl',
+}
+
+/**
+ * Check if a string is an emoji avatar (vs a URL)
+ */
+function isEmoji(str: string): boolean {
+  // Emoji strings are typically 1-4 characters and contain emoji codepoints
+  return str.length <= 8 && /\p{Emoji}/u.test(str)
+}
+
+export default function BotAvatar({
+  avatarUrl,
+  name,
+  size = 'md',
+  className,
+}: BotAvatarProps) {
+  const sizeClass = SIZE_CLASSES[size]
+
+  // If we have an emoji avatar, display it directly
+  if (avatarUrl && isEmoji(avatarUrl)) {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center rounded-full bg-purple-100 dark:bg-purple-900/50',
+          sizeClass,
+          className
+        )}
+        title={name}
+        role="img"
+        aria-label={`${name} avatar`}
+      >
+        <span className="leading-none">{avatarUrl}</span>
+      </div>
+    )
+  }
+
+  // If we have a URL avatar, display as image
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={`${name} avatar`}
+        className={cn('rounded-full object-cover', sizeClass, className)}
+      />
+    )
+  }
+
+  // Fallback: robot icon
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded-full bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300',
+        sizeClass,
+        className
+      )}
+      title={name}
+      role="img"
+      aria-label={`${name} avatar`}
+    >
+      <svg
+        className="w-1/2 h-1/2"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path d="M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1v1a2 2 0 01-2 2H5a2 2 0 01-2-2v-1H2a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2M7.5 13A1.5 1.5 0 006 14.5 1.5 1.5 0 007.5 16 1.5 1.5 0 009 14.5 1.5 1.5 0 007.5 13m9 0a1.5 1.5 0 00-1.5 1.5 1.5 1.5 0 001.5 1.5 1.5 1.5 0 001.5-1.5 1.5 1.5 0 00-1.5-1.5z" />
+      </svg>
+    </div>
+  )
+}

--- a/src/components/BotPersonaSelector.tsx
+++ b/src/components/BotPersonaSelector.tsx
@@ -6,6 +6,7 @@
 
 import { Button } from './ui/button'
 import { useBotPersonas, type BotPersona } from '../hooks/useBotPersonas'
+import BotAvatar from './BotAvatar'
 
 interface BotPersonaSelectorProps {
   selectedPersonaId: string | null
@@ -60,15 +61,22 @@ function BotPersonaCard({
         }
       `}
     >
-      {/* Header with name and rating */}
+      {/* Header with avatar, name and rating */}
       <div className="flex justify-between items-start mb-2">
-        <div>
-          <h3 className="font-semibold text-lg">{persona.name}</h3>
-          <span
-            className={`text-sm font-medium ${getRatingTierColor(persona.rating)}`}
-          >
-            {persona.rating} - {getRatingTierName(persona.rating)}
-          </span>
+        <div className="flex items-start gap-3">
+          <BotAvatar
+            avatarUrl={persona.avatarUrl}
+            name={persona.name}
+            size="md"
+          />
+          <div>
+            <h3 className="font-semibold text-lg">{persona.name}</h3>
+            <span
+              className={`text-sm font-medium ${getRatingTierColor(persona.rating)}`}
+            >
+              {persona.rating} - {getRatingTierName(persona.rating)}
+            </span>
+          </div>
         </div>
         {/* Play style badge */}
         <span

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -15,6 +15,7 @@ import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { cn } from '@/lib/utils'
 import { useGameChat, QUICK_REACTIONS, type ChatMessage } from '../hooks/useGameChat'
+import BotAvatar from './BotAvatar'
 
 interface ChatPanelProps {
   gameId: string | null
@@ -24,6 +25,10 @@ interface ChatPanelProps {
   className?: string
   /** Current move count - used to trigger bot reactions after player moves */
   moveCount?: number
+  /** Bot avatar URL (emoji or image URL) for displaying next to bot messages */
+  botAvatarUrl?: string | null
+  /** Bot name for display in chat */
+  botName?: string
 }
 
 export default function ChatPanel({
@@ -33,6 +38,8 @@ export default function ChatPanel({
   playerNumber = 1,
   className,
   moveCount = 0,
+  botAvatarUrl,
+  botName = 'Bot',
 }: ChatPanelProps) {
   const {
     messages,
@@ -103,7 +110,7 @@ export default function ChatPanel({
 
   const getSenderName = (message: ChatMessage) => {
     if (message.sender_type === 'bot') {
-      return 'Bot'
+      return botName
     }
     // Check if this is the current player's message
     if (message.sender_id === 'self') {
@@ -203,25 +210,37 @@ export default function ChatPanel({
                 <div
                   key={message.id}
                   className={cn(
-                    'flex flex-col max-w-[85%]',
-                    isOwnMessage(message) ? 'ml-auto items-end' : 'items-start'
+                    'flex max-w-[85%]',
+                    isOwnMessage(message) ? 'ml-auto flex-row-reverse' : 'flex-row',
+                    'gap-2'
                   )}
                 >
-                  <div
-                    className={cn(
-                      'rounded-lg px-3 py-1.5 text-sm',
-                      message.sender_type === 'bot'
-                        ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-900 dark:text-purple-100'
-                        : isOwnMessage(message)
-                          ? 'bg-primary text-primary-foreground'
-                          : 'bg-muted'
-                    )}
-                  >
-                    {message.content}
+                  {/* Bot avatar */}
+                  {message.sender_type === 'bot' && (
+                    <BotAvatar
+                      avatarUrl={botAvatarUrl ?? null}
+                      name={botName}
+                      size="xs"
+                      className="flex-shrink-0 mt-0.5"
+                    />
+                  )}
+                  <div className="flex flex-col">
+                    <div
+                      className={cn(
+                        'rounded-lg px-3 py-1.5 text-sm',
+                        message.sender_type === 'bot'
+                          ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-900 dark:text-purple-100'
+                          : isOwnMessage(message)
+                            ? 'bg-primary text-primary-foreground'
+                            : 'bg-muted'
+                      )}
+                    >
+                      {message.content}
+                    </div>
+                    <span className="text-xs text-muted-foreground mt-0.5">
+                      {getSenderName(message)} · {formatTime(message.created_at)}
+                    </span>
                   </div>
-                  <span className="text-xs text-muted-foreground mt-0.5">
-                    {getSenderName(message)} · {formatTime(message.created_at)}
-                  </span>
                 </div>
               ))
             )}

--- a/src/pages/BotProfilePage.tsx
+++ b/src/pages/BotProfilePage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import ThemeToggle from '../components/ThemeToggle'
+import BotAvatar from '../components/BotAvatar'
 
 interface RecentGame {
   id: string
@@ -143,11 +144,11 @@ export default function BotProfilePage() {
               <CardHeader>
                 <div className="flex items-start justify-between">
                   <div className="flex items-center gap-4">
-                    <div className="w-16 h-16 rounded-full bg-purple-100 dark:bg-purple-900 flex items-center justify-center">
-                      <svg className="w-8 h-8 text-purple-700 dark:text-purple-300" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                        <path d="M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1v1a2 2 0 01-2 2H5a2 2 0 01-2-2v-1H2a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2zm-3 13a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm6 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
-                      </svg>
-                    </div>
+                    <BotAvatar
+                      avatarUrl={profile.avatarUrl}
+                      name={profile.name}
+                      size="xl"
+                    />
                     <div>
                       <CardTitle className="text-2xl">{profile.name}</CardTitle>
                       <CardDescription className="mt-1">{profile.description}</CardDescription>

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
 import ThemeToggle from '../components/ThemeToggle'
+import BotAvatar from '../components/BotAvatar'
 
 interface LeaderboardEntry {
   rank: number
@@ -18,6 +19,7 @@ interface LeaderboardEntry {
   isBot: boolean
   botPersonaId: string | null
   botDescription: string | null
+  botAvatarUrl: string | null
 }
 
 interface LeaderboardResponse {
@@ -175,14 +177,11 @@ export default function LeaderboardPage() {
                           <td className="py-3 px-2 font-medium">
                             <div className="flex items-center gap-2">
                               {entry.isBot && (
-                                <span
-                                  className="inline-flex items-center justify-center w-5 h-5 rounded bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 text-xs"
-                                  title={entry.botDescription || 'Bot opponent'}
-                                >
-                                  <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                    <path d="M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1v1a2 2 0 01-2 2H5a2 2 0 01-2-2v-1H2a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2zm-3 13a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm6 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
-                                  </svg>
-                                </span>
+                                <BotAvatar
+                                  avatarUrl={entry.botAvatarUrl}
+                                  name={entry.username}
+                                  size="xs"
+                                />
                               )}
                               <Link
                                 to={entry.isBot ? `/bot/${entry.botPersonaId}` : '#'}

--- a/src/pages/PlayPage.tsx
+++ b/src/pages/PlayPage.tsx
@@ -10,6 +10,7 @@ import GameBoard from '../components/GameBoard'
 import AnalysisPanel from '../components/AnalysisPanel'
 import ChatPanel from '../components/ChatPanel'
 import BotPersonaSelector from '../components/BotPersonaSelector'
+import BotAvatar from '../components/BotAvatar'
 import { GameTimers } from '../components/GameTimer'
 import {
   createGameState,
@@ -945,9 +946,17 @@ export default function PlayPage() {
             </div>
             <span className="text-muted-foreground">vs</span>
             <div className="flex items-center gap-2">
-              <div
-                className={`w-4 h-4 rounded-full ${game.playerNumber === 1 ? 'bg-yellow-400' : 'bg-red-500'}`}
-              />
+              {selectedPersona?.avatarUrl ? (
+                <BotAvatar
+                  avatarUrl={selectedPersona.avatarUrl}
+                  name={botName}
+                  size="xs"
+                />
+              ) : (
+                <div
+                  className={`w-4 h-4 rounded-full ${game.playerNumber === 1 ? 'bg-yellow-400' : 'bg-red-500'}`}
+                />
+              )}
               <span className="text-sm font-medium">
                 {botName} ({botColor}) - {game.opponentRating}
               </span>
@@ -1029,6 +1038,8 @@ export default function PlayPage() {
             playerNumber={game.playerNumber}
             moveCount={game.moves.length}
             className="w-full mt-4"
+            botAvatarUrl={selectedPersona?.avatarUrl}
+            botName={selectedPersona?.name || botName}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Add emoji-based avatars for all 11 bot personas providing distinctive visual identity
- Create reusable `BotAvatar` component supporting emoji and URL-based avatars
- Integrate avatars across all UI touchpoints: bot selector, profile pages, leaderboard, in-game display, and chat messages

## Bot Avatars
| Bot | Emoji | Meaning |
|-----|-------|---------|
| Rookie | 🌱 | Seedling - just starting |
| Rusty | 🔧 | Wrench - old-timer |
| Blitz | ⚡ | Lightning - fast/energetic |
| Nova | ⭐ | Star - rising star |
| Neuron | 🧠 | Brain - analytical |
| Scholar | 📚 | Books - studious |
| Viper | 🐍 | Snake - cunning |
| Titan | 🏔️ | Mountain - powerful |
| Sentinel | 🛡️ | Shield - defender |
| Oracle | 🔮 | Crystal ball - seer |

## Test plan
- [ ] Verify avatars display in bot selector cards
- [ ] Verify avatars display on bot profile pages
- [ ] Verify avatars display in leaderboard entries for bots
- [ ] Verify avatars display during ranked bot games
- [ ] Verify avatars display next to bot chat messages
- [ ] Verify fallback robot icon displays when avatarUrl is null
- [ ] Build passes without errors
- [ ] All tests pass

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)