### PR TITLE
feat: implement player vs bot stats tracking (#73)

### DIFF
--- a/functions/api/users/me/bot-stats.ts
+++ b/functions/api/users/me/bot-stats.ts
@@ -1,0 +1,180 @@
+/**
+ * Bot Stats API endpoint
+ *
+ * GET /api/users/me/bot-stats - Get player's stats against all bots
+ */
+
+import { validateSession, errorResponse, jsonResponse } from '../../../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+interface PlayerBotStatsRow {
+  user_id: string
+  bot_persona_id: string
+  wins: number
+  losses: number
+  draws: number
+  current_streak: number
+  best_win_streak: number
+  first_win_at: number | null
+  last_played_at: number
+  // Joined from bot_personas
+  bot_name: string
+  bot_play_style: string
+  bot_current_elo: number
+}
+
+interface BotStatsResponse {
+  botId: string
+  botName: string
+  botPlayStyle: string
+  botRating: number
+  wins: number
+  losses: number
+  draws: number
+  totalGames: number
+  winRate: number
+  currentStreak: number
+  bestWinStreak: number
+  firstWinAt: number | null
+  lastPlayedAt: number
+  // Derived status flags
+  hasPositiveRecord: boolean
+  isUndefeated: boolean
+  isMastered: boolean // 10+ wins, >60% win rate
+}
+
+/**
+ * GET /api/users/me/bot-stats - Get player's stats against all bots
+ */
+export async function onRequestGet(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Get all bot stats for this user, joined with bot personas for names
+    const stats = await DB.prepare(`
+      SELECT
+        pbs.user_id,
+        pbs.bot_persona_id,
+        pbs.wins,
+        pbs.losses,
+        pbs.draws,
+        pbs.current_streak,
+        pbs.best_win_streak,
+        pbs.first_win_at,
+        pbs.last_played_at,
+        bp.name as bot_name,
+        bp.play_style as bot_play_style,
+        bp.current_elo as bot_current_elo
+      FROM player_bot_stats pbs
+      JOIN bot_personas bp ON pbs.bot_persona_id = bp.id
+      WHERE pbs.user_id = ?
+      ORDER BY pbs.last_played_at DESC
+    `)
+      .bind(session.userId)
+      .all<PlayerBotStatsRow>()
+
+    // Transform to response format
+    const botStats: BotStatsResponse[] = stats.results.map((row) => {
+      const totalGames = row.wins + row.losses + row.draws
+      const winRate = totalGames > 0 ? (row.wins / totalGames) * 100 : 0
+
+      return {
+        botId: row.bot_persona_id,
+        botName: row.bot_name,
+        botPlayStyle: row.bot_play_style,
+        botRating: row.bot_current_elo,
+        wins: row.wins,
+        losses: row.losses,
+        draws: row.draws,
+        totalGames,
+        winRate: Math.round(winRate * 10) / 10,
+        currentStreak: row.current_streak,
+        bestWinStreak: row.best_win_streak,
+        firstWinAt: row.first_win_at,
+        lastPlayedAt: row.last_played_at,
+        hasPositiveRecord: row.wins > row.losses,
+        isUndefeated: row.losses === 0 && row.wins > 0,
+        isMastered: row.wins >= 10 && winRate > 60,
+      }
+    })
+
+    // Also get list of bots the user has never played
+    const unplayedBots = await DB.prepare(`
+      SELECT bp.id, bp.name, bp.play_style, bp.current_elo
+      FROM bot_personas bp
+      WHERE bp.is_active = 1
+        AND bp.id NOT IN (
+          SELECT bot_persona_id FROM player_bot_stats WHERE user_id = ?
+        )
+      ORDER BY bp.current_elo ASC
+    `)
+      .bind(session.userId)
+      .all<{ id: string; name: string; play_style: string; current_elo: number }>()
+
+    const unplayed = unplayedBots.results.map((bot) => ({
+      botId: bot.id,
+      botName: bot.name,
+      botPlayStyle: bot.play_style,
+      botRating: bot.current_elo,
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      totalGames: 0,
+      winRate: 0,
+      currentStreak: 0,
+      bestWinStreak: 0,
+      firstWinAt: null,
+      lastPlayedAt: null,
+      hasPositiveRecord: false,
+      isUndefeated: false,
+      isMastered: false,
+    }))
+
+    // Calculate summary stats
+    const totalWins = botStats.reduce((sum, s) => sum + s.wins, 0)
+    const totalLosses = botStats.reduce((sum, s) => sum + s.losses, 0)
+    const totalDraws = botStats.reduce((sum, s) => sum + s.draws, 0)
+    const totalGames = totalWins + totalLosses + totalDraws
+    const botsPlayed = botStats.length
+    const botsDefeated = botStats.filter((s) => s.wins > 0).length
+    const botsMastered = botStats.filter((s) => s.isMastered).length
+
+    return jsonResponse({
+      stats: botStats,
+      unplayed,
+      summary: {
+        totalGames,
+        totalWins,
+        totalLosses,
+        totalDraws,
+        overallWinRate: totalGames > 0 ? Math.round((totalWins / totalGames) * 1000) / 10 : 0,
+        botsPlayed,
+        botsDefeated,
+        botsMastered,
+        botsRemaining: unplayed.length,
+      },
+    })
+  } catch (error) {
+    console.error('GET /api/users/me/bot-stats error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  })
+}

--- a/functions/api/users/me/bot-stats/[botId].ts
+++ b/functions/api/users/me/bot-stats/[botId].ts
@@ -1,0 +1,108 @@
+/**
+ * Bot Stats API endpoint for specific bot
+ *
+ * GET /api/users/me/bot-stats/:botId - Get player's stats against a specific bot
+ */
+
+import { validateSession, errorResponse, jsonResponse } from '../../../../lib/auth'
+
+interface Env {
+  DB: D1Database
+}
+
+interface PlayerBotStatsRow {
+  wins: number
+  losses: number
+  draws: number
+  current_streak: number
+  best_win_streak: number
+  first_win_at: number | null
+  last_played_at: number
+}
+
+interface BotPersonaRow {
+  id: string
+  name: string
+  play_style: string
+  current_elo: number
+  description: string
+}
+
+/**
+ * GET /api/users/me/bot-stats/:botId - Get player's stats against a specific bot
+ */
+export async function onRequestGet(context: EventContext<Env, any, any>) {
+  const { DB } = context.env
+  const botId = context.params.botId as string
+
+  try {
+    const session = await validateSession(context.request, DB)
+    if (!session.valid) {
+      return errorResponse(session.error, session.status)
+    }
+
+    // Get bot info
+    const bot = await DB.prepare(`
+      SELECT id, name, play_style, current_elo, description
+      FROM bot_personas
+      WHERE id = ? AND is_active = 1
+    `)
+      .bind(botId)
+      .first<BotPersonaRow>()
+
+    if (!bot) {
+      return errorResponse('Bot not found', 404)
+    }
+
+    // Get stats for this user against this bot
+    const stats = await DB.prepare(`
+      SELECT wins, losses, draws, current_streak, best_win_streak, first_win_at, last_played_at
+      FROM player_bot_stats
+      WHERE user_id = ? AND bot_persona_id = ?
+    `)
+      .bind(session.userId, botId)
+      .first<PlayerBotStatsRow>()
+
+    // If no stats exist, return default values
+    const wins = stats?.wins ?? 0
+    const losses = stats?.losses ?? 0
+    const draws = stats?.draws ?? 0
+    const totalGames = wins + losses + draws
+    const winRate = totalGames > 0 ? (wins / totalGames) * 100 : 0
+
+    return jsonResponse({
+      botId: bot.id,
+      botName: bot.name,
+      botPlayStyle: bot.play_style,
+      botRating: bot.current_elo,
+      botDescription: bot.description,
+      wins,
+      losses,
+      draws,
+      totalGames,
+      winRate: Math.round(winRate * 10) / 10,
+      currentStreak: stats?.current_streak ?? 0,
+      bestWinStreak: stats?.best_win_streak ?? 0,
+      firstWinAt: stats?.first_win_at ?? null,
+      lastPlayedAt: stats?.last_played_at ?? null,
+      hasPositiveRecord: wins > losses,
+      isUndefeated: losses === 0 && wins > 0,
+      isMastered: wins >= 10 && winRate > 60,
+      hasPlayed: totalGames > 0,
+    })
+  } catch (error) {
+    console.error('GET /api/users/me/bot-stats/:botId error:', error)
+    return errorResponse('Internal server error', 500)
+  }
+}
+
+export async function onRequestOptions() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  })
+}

--- a/migrations/006_add_player_bot_stats.sql
+++ b/migrations/006_add_player_bot_stats.sql
@@ -1,0 +1,29 @@
+-- Add player vs bot stats tracking
+-- Tracks per-player records against each bot for progression and achievements
+
+-- Player vs bot stats table
+CREATE TABLE IF NOT EXISTS player_bot_stats (
+  user_id TEXT NOT NULL,
+  bot_persona_id TEXT NOT NULL,
+  wins INTEGER NOT NULL DEFAULT 0,
+  losses INTEGER NOT NULL DEFAULT 0,
+  draws INTEGER NOT NULL DEFAULT 0,
+  -- Current streak: positive = win streak, negative = loss streak
+  current_streak INTEGER NOT NULL DEFAULT 0,
+  best_win_streak INTEGER NOT NULL DEFAULT 0,
+  -- Timestamp of first win against this bot (milestone)
+  first_win_at INTEGER,
+  last_played_at INTEGER NOT NULL,
+  PRIMARY KEY (user_id, bot_persona_id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (bot_persona_id) REFERENCES bot_personas(id) ON DELETE CASCADE
+);
+
+-- Indexes for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_player_bot_stats_user ON player_bot_stats(user_id);
+CREATE INDEX IF NOT EXISTS idx_player_bot_stats_bot ON player_bot_stats(bot_persona_id);
+CREATE INDEX IF NOT EXISTS idx_player_bot_stats_last_played ON player_bot_stats(last_played_at DESC);
+
+-- Index for looking up games by bot persona
+CREATE INDEX IF NOT EXISTS idx_games_bot_persona ON games(bot_persona_id)
+  WHERE bot_persona_id IS NOT NULL;

--- a/src/hooks/usePlayerBotStats.ts
+++ b/src/hooks/usePlayerBotStats.ts
@@ -1,0 +1,144 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useAuthenticatedApi } from './useAuthenticatedApi'
+
+export interface BotStatsRecord {
+  botId: string
+  botName: string
+  botPlayStyle: string
+  botRating: number
+  wins: number
+  losses: number
+  draws: number
+  totalGames: number
+  winRate: number
+  currentStreak: number
+  bestWinStreak: number
+  firstWinAt: number | null
+  lastPlayedAt: number | null
+  hasPositiveRecord: boolean
+  isUndefeated: boolean
+  isMastered: boolean
+}
+
+export interface BotStatsSummary {
+  totalGames: number
+  totalWins: number
+  totalLosses: number
+  totalDraws: number
+  overallWinRate: number
+  botsPlayed: number
+  botsDefeated: number
+  botsMastered: number
+  botsRemaining: number
+}
+
+export interface PlayerBotStatsResponse {
+  stats: BotStatsRecord[]
+  unplayed: BotStatsRecord[]
+  summary: BotStatsSummary
+}
+
+export interface SingleBotStatsResponse extends BotStatsRecord {
+  botDescription: string
+  hasPlayed: boolean
+}
+
+/**
+ * Hook for fetching player's stats against all bots
+ */
+export function usePlayerBotStats() {
+  const { apiCall, getSessionToken } = useAuthenticatedApi()
+  const [data, setData] = useState<PlayerBotStatsResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchStats = useCallback(async () => {
+    const token = getSessionToken()
+    if (!token) {
+      setData(null)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await apiCall<PlayerBotStatsResponse>('/api/users/me/bot-stats')
+      setData(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }, [apiCall, getSessionToken])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  return { data, loading, error, refetch: fetchStats }
+}
+
+/**
+ * Hook for fetching player's stats against a specific bot
+ */
+export function useSingleBotStats(botId: string | null) {
+  const { apiCall, getSessionToken } = useAuthenticatedApi()
+  const [data, setData] = useState<SingleBotStatsResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchStats = useCallback(async () => {
+    const token = getSessionToken()
+    if (!token || !botId) {
+      setData(null)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const result = await apiCall<SingleBotStatsResponse>(`/api/users/me/bot-stats/${botId}`)
+      setData(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }, [apiCall, getSessionToken, botId])
+
+  useEffect(() => {
+    fetchStats()
+  }, [fetchStats])
+
+  return { data, loading, error, refetch: fetchStats }
+}
+
+/**
+ * Format a record as "W-L" or "W-L-D" string
+ */
+export function formatRecord(wins: number, losses: number, draws: number = 0): string {
+  if (draws > 0) {
+    return `${wins}-${losses}-${draws}`
+  }
+  return `${wins}-${losses}`
+}
+
+/**
+ * Get a streak description string
+ */
+export function formatStreak(streak: number): string {
+  if (streak === 0) return ''
+  if (streak > 0) return `${streak}W streak`
+  return `${Math.abs(streak)}L streak`
+}
+
+/**
+ * Get record indicator icon
+ */
+export function getRecordIndicator(wins: number, losses: number): string {
+  if (wins > losses) return '✅'
+  if (losses > wins) return '❌'
+  return '➖'
+}


### PR DESCRIPTION
## Summary
- Add `player_bot_stats` table to track per-player records against each bot
- Create API endpoints for bot stats retrieval
- Update game completion to track win/loss/draw counts, streaks, and milestones per bot
- Add "Bot Records" tab to profile page with progress summary and individual records
- Show player's record in bot selector cards
- Display post-game stats with record updates, streak notifications, and celebrations

## Changes

### Database
- New `player_bot_stats` table with columns for wins, losses, draws, current/best streaks, first win timestamp
- Added `bot_persona_id` foreign key to `games` table for bot game tracking
- Migration `006_add_player_bot_stats.sql` for the new table and index

### API
- `GET /api/users/me/bot-stats` - Returns all bot stats for player with summary
- `GET /api/users/me/bot-stats/:botId` - Returns stats against specific bot

### Frontend
- New `usePlayerBotStats` hook for fetching bot stats
- ProfilePage: Added "Bot Records" tab with progress summary and individual bot records
- BotPersonaSelector: Shows player's record on each bot card
- PlayPage: Post-game display showing updated record, streaks, first win, and mastery

## Test plan
- [ ] Play a ranked bot game and verify stats are tracked
- [ ] Check profile page Bot Records tab shows correct stats
- [ ] Verify bot selector cards show player's record
- [ ] Confirm post-game screen shows record and streak info
- [ ] Test first win and mastery celebrations

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)